### PR TITLE
feat: add Connector templates download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/camunda/connectors-bundle/actions/workflows/CI.yml/badge.svg)](https://github.com/camunda/connectors-bundle/actions/workflows/CI.yml)
 
-The connectors bundle contains all out of the box connectors for Camunda 8. It's an easy way to try them out in your local setup or in k8s.
+The Connectors Bundle contains all out-of-the-box Connectors for Camunda 8. It's an easy way to try them out in your local setup or in k8s.
 
 The bundle contains the following components
 
@@ -60,6 +60,11 @@ docker build \
          --build-arg SLACK_VERSION=0.5.0  \         # Overwrite slack connector version
          -t camunda/connectors-bundle:${VERSION} .
 ```
+
+# Connector templates
+
+You can use the provided [download script](./download-templates.sh) to fetch the latest Connector templates of all out-of-the-box Connectors.
+Adjust the versions in the top of the script if you don't want to use the latest versions.
 
 # License
 

--- a/download-templates.sh
+++ b/download-templates.sh
@@ -1,0 +1,15 @@
+AWS_LAMBDA_VERSION=0.3.0
+GOOGLE_DRIVE_VERSION=0.4.0
+HTTP_JSON_VERSION=0.9.0
+SENDGRID_VERSION=0.11.0
+SLACK_VERSION=0.4.0
+SQS_VERSION=0.2.0
+
+wget -i - << EOF
+https://github.com/camunda/connector-aws-lambda/releases/download/$AWS_LAMBDA_VERSION/aws-lambda-connector.json
+https://github.com/camunda/connector-google-drive/releases/download/$GOOGLE_DRIVE_VERSION/google-drive-connector.json
+https://github.com/camunda/connector-http-json/releases/download/$HTTP_JSON_VERSION/http-json-connector.json
+https://github.com/camunda/connector-sendgrid/releases/download/$SENDGRID_VERSION/sendgrid-connector.json
+https://github.com/camunda/connector-slack/releases/download/$SLACK_VERSION/slack-connector.json
+https://github.com/camunda/connector-sqs/releases/download/$SQS_VERSION/aws-sqs-connector.json
+EOF


### PR DESCRIPTION
## Description

Provides a script that downloads all latest element templates matching the versions of the runtimes in the Docker image.

## Related issues

closes #11 

