### PR TITLE
chore: publish templates with `-version` qualifier

### DIFF
--- a/bundle-templates.sh
+++ b/bundle-templates.sh
@@ -20,6 +20,25 @@ https://github.com/camunda/connector-slack/releases/download/${SLACK_VERSION}/sl
 https://github.com/camunda/connector-sqs/releases/download/${SQS_VERSION}/aws-sqs-connector.json
 EOF
 
+tag_version() {
+  local file=$1
+  local version=$(cat $file | jq '. | if type == "array" then .[0] else . end | .version')
+
+  local base_name="${file%%".json"*}"
+
+  if [[ "null" != "$version" ]]; then
+    echo "tag_version: Renaming $file -> $base_name-$version.json"
+
+    mv "$file" "$base_name-$version.json"
+  else
+    echo "tag_version: Keeping $file (unversioned)"
+  fi
+}
+
+for file in *.json; do
+  tag_version $file
+done
+
 tar czvf ${ARTIFACT_DIR}/connectors-bundle-templates-${RELEASE_VERSION}.tar.gz *.json
 zip ${ARTIFACT_DIR}/connectors-bundle-templates-${RELEASE_VERSION}.zip *.json
 


### PR DESCRIPTION
## Description

Ensures we publish templates with a `-$version` qualifier.

Example: If `slack-connector.json` has a `.version` field _THEN_ we rename it to `slack-connector-$version.json`.

Gracefully handles missing version (does not rename).
Gracefully handles templates packed as arrays (we should get rid of these).

## Related issues

Related to https://github.com/camunda/team-connectors/issues/170

