### PR TITLE
chore: bump to SDK `0.3.0` and related Connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,13 @@
-# Camunda 8 Connectors Bundle
+# Camunda 8 Connectors
 
 [![CI](https://github.com/camunda/connectors-bundle/actions/workflows/CI.yml/badge.svg)](https://github.com/camunda/connectors-bundle/actions/workflows/CI.yml)
 
-The connectors bundle contains all out of the box connectors for Camunda 8. It's an easy way to try them out in your local setup or in k8s.
-
-The bundle contains the following components
-
-| Component                    | Version | License                                      |
-| ---------------------------- |---------| -------------------------------------------- |
-| [Connector Runtime]          | 8.1.3   | [Apache 2.0]                                 |
-| [AWS Lambda Connector]       | 0.3.2   | [Camunda Platform Self-Managed Free Edition] |
-| [Google Drive Connector]     | 0.4.0   | [Camunda Platform Self-Managed Free Edition] |
-| [HTTP JSON Connector (REST)] | 0.9.0   | [Apache 2.0]                                 |
-| [SendGrid Connector]         | 0.11.0  | [Camunda Platform Self-Managed Free Edition] |
-| [Slack Connector]            | 0.4.0   | [Camunda Platform Self-Managed Free Edition] |
-| [SQS Connector]              | 0.2.0   | [Camunda Platform Self-Managed Free Edition] |
-
-The [`Dockerfile`](./Dockerfile) provides an image including the [Connector runtime]
-and all [out-of-the-box Connectors](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/)
-provided by Camunda. The image starts the Connector runtime with all `jar`
-files provided in the `/opt/app` directory as classpath.
-
-To add more connectors to the image follow the examples in the [Docker Connector Runtime Image](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#via-docker)
-section.
-
-# Secrets
-
-To inject secrets into the docker container during runtime, they have to be
-available in the environment of the docker container.
-
-For example, you can inject secrets when running a container:
-
-```bash
-docker run --rm --name=connectors -d \
-           -v $PWD/connector.jar:/opt/app/ \  # Add a connector jar to the classpath
-           -e MY_SECRET=secret \              # Set a secret with value
-           -e SECRET_FROM_SHELL \             # Set a secret from the environment
-           --env-file secrets.txt \           # Set secrets from a file
-           camunda/connectors-bundle:0.1.0
-```
-
-The secret `MY_SECRET` value is specified directly in the `docker run` call,
-whereas the `SECRET_FROM_SHELL` is injected based on the value in the
-current shell environment when `docker run` is executed. The `--env-file`
-option allows using a single file with the format `NAME=VALUE` per line
-to inject multiple secrets at once.
-
-# Build
-
-```bash
-docker build -t camunda/connectors-bundle:${VERSION} .
-```
-
-All version can be overwritten as build args, i.e. to use a different runtime version and slack connector version run
-
-```bash
-docker build \
-         --build-arg RUNTIME_VERSION=0.3.0 \        # Overwrite job worker runtime version
-         --build-arg SLACK_VERSION=0.5.0  \         # Overwrite slack connector version
-         -t camunda/connectors-bundle:${VERSION} .
-```
+This repository manages two Docker images:
+* [Connectors Bundle](./bundle) - All out-of-the-box Connectors for Camunda 8, bundled with a runtime.
+* [Connector Runtime](./runtime) - Execution environment for any Connector, without any preconfigured Connector.
 
 # License
 
 [Apache 2.0]
 
-The docker image contains connectors licensed under [Camunda Platform Self-Managed Free Edition] license.
-
-[apache 2.0]: https://www.apache.org/licenses/LICENSE-2.0
-[aws lambda connector]: https://github.com/camunda/connector-aws-lambda
-[camunda platform self-managed free edition]: https://camunda.com/legal/terms/cloud-terms-and-conditions/camunda-cloud-self-managed-free-edition-terms/
-[google drive connector]: https://github.com/camunda/connector-google-drive
-[http json connector (rest)]: https://github.com/camunda/connector-http-json
-[connector runtime]: https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime
-[sendgrid connector]: https://github.com/camunda/connector-sendgrid
-[slack connector]: https://github.com/camunda/connector-slack
-[sqs connector]: https://github.com/camunda/connector-sqs
+The Connectors Bundle Docker image contains Connectors licensed under [Camunda Platform Self-Managed Free Edition] license.

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -1,20 +1,24 @@
 # Configure the connector runtime version
-ARG RUNTIME_VERSION=0.2.2
+ARG RUNTIME_VERSION=0.3.0
 FROM camunda/connectors:${RUNTIME_VERSION}
 
 # Configure versions of included connectors
-ARG AWS_LAMBDA_VERSION=0.3.2
-ARG GOOGLE_DRIVE_VERSION=0.4.0
-ARG HTTP_JSON_VERSION=0.9.0
-ARG SENDGRID_VERSION=0.11.0
-ARG SLACK_VERSION=0.4.0
-ARG SQS_VERSION=0.2.0
+ARG AWS_LAMBDA_VERSION=0.4.0
+ARG GOOGLE_DRIVE_VERSION=0.5.0
+ARG HTTP_JSON_VERSION=0.11.0
+ARG RABBITMQ_VERSION=0.1.0
+ARG SENDGRID_VERSION=0.13.0
+ARG SLACK_VERSION=0.6.0
+ARG SNS_VERSION=0.1.1
+ARG SQS_VERSION=0.3.0
 
 # Download connectors from maven central
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-aws-lambda/${AWS_LAMBDA_VERSION}/connector-aws-lambda-${AWS_LAMBDA_VERSION}-with-dependencies.jar /opt/app/
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-google-drive/${GOOGLE_DRIVE_VERSION}/connector-google-drive-${GOOGLE_DRIVE_VERSION}-with-dependencies.jar /opt/app/
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/${HTTP_JSON_VERSION}/connector-http-json-${HTTP_JSON_VERSION}-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-rabbitmq/${RABBITMQ_VERSION}/connector-rabbitmq-${RABBITMQ_VERSION}-with-dependencies.jar /opt/app/
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-sendgrid/${SENDGRID_VERSION}/connector-sendgrid-${SENDGRID_VERSION}-with-dependencies.jar /opt/app/
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-slack/${SLACK_VERSION}/connector-slack-${SLACK_VERSION}-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-sns/${SNS_VERSION}/connector-sns-${SNS_VERSION}-with-dependencies.jar /opt/app/
 ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-sqs/${SQS_VERSION}/connector-sqs-${SQS_VERSION}-with-dependencies.jar /opt/app/
 

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,0 +1,79 @@
+# Camunda 8 Connectors Bundle
+
+The Connectors Bundle contains all out-of-the-box Connectors for Camunda 8. It's an easy way to try them out in your local setup or in k8s.
+
+The bundle contains the following components
+
+| Component                    | Version | License                                      |
+| ---------------------------- |---------| -------------------------------------------- |
+| [Connector Runtime]          | 0.3.0   | [Apache 2.0]                                 |
+| [AWS Lambda Connector]       | 0.4.0   | [Camunda Platform Self-Managed Free Edition] |
+| [Google Drive Connector]     | 0.5.0   | [Camunda Platform Self-Managed Free Edition] |
+| [HTTP JSON Connector (REST)] | 0.11.0  | [Apache 2.0]                                 |
+| [RabbitMQ Connector]         | 0.1.0   | [Camunda Platform Self-Managed Free Edition] |
+| [SendGrid Connector]         | 0.13.0  | [Camunda Platform Self-Managed Free Edition] |
+| [Slack Connector]            | 0.6.0   | [Camunda Platform Self-Managed Free Edition] |
+| [SNS Connector]              | 0.1.1   | [Camunda Platform Self-Managed Free Edition] |
+| [SQS Connector]              | 0.3.0   | [Camunda Platform Self-Managed Free Edition] |
+
+The [`Dockerfile`](./Dockerfile) provides an image including the [Connector runtime]
+and all [out-of-the-box Connectors](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/)
+provided by Camunda. The image starts the Connector runtime with all `jar`
+files provided in the `/opt/app` directory as classpath.
+
+To add more connectors to the image, follow the examples in the [Connector Runtime].
+
+# Secrets
+
+To inject secrets into the docker container during runtime, they have to be
+available in the environment of the docker container.
+
+For example, you can inject secrets when running a container:
+
+```bash
+docker run --rm --name=connectors -d \
+           -v $PWD/connector.jar:/opt/app/ \  # Add a connector jar to the classpath
+           -e MY_SECRET=secret \              # Set a secret with value
+           -e SECRET_FROM_SHELL \             # Set a secret from the environment
+           --env-file secrets.txt \           # Set secrets from a file
+           camunda/connectors-bundle:0.3.0
+```
+
+The secret `MY_SECRET` value is specified directly in the `docker run` call,
+whereas the `SECRET_FROM_SHELL` is injected based on the value in the
+current shell environment when `docker run` is executed. The `--env-file`
+option allows using a single file with the format `NAME=VALUE` per line
+to inject multiple secrets at once.
+
+# Build
+
+```bash
+docker build -t camunda/connectors-bundle:${VERSION} .
+```
+
+All version can be overwritten as build args, i.e. to use a different runtime version and slack connector version run
+
+```bash
+docker build \
+         --build-arg RUNTIME_VERSION=8.1.6 \        # Overwrite Connector runtime version
+         --build-arg SLACK_VERSION=0.5.0  \         # Overwrite Slack Connector version
+         -t camunda/connectors-bundle:${VERSION} .
+```
+
+# License
+
+[Apache 2.0]
+
+The docker image contains Connectors licensed under [Camunda Platform Self-Managed Free Edition] license.
+
+[apache 2.0]: https://www.apache.org/licenses/LICENSE-2.0
+[aws lambda connector]: https://github.com/camunda/connector-aws-lambda
+[camunda platform self-managed free edition]: https://camunda.com/legal/terms/cloud-terms-and-conditions/camunda-cloud-self-managed-free-edition-terms/
+[google drive connector]: https://github.com/camunda/connector-google-drive
+[http json connector (rest)]: https://github.com/camunda/connector-http-json
+[rabbitmq connector]: https://github.com/camunda/connector-rabbitmq
+[connector runtime]: https://github.com/camunda/connectors-bundle/tree/main/runtime
+[sendgrid connector]: https://github.com/camunda/connector-sendgrid
+[slack connector]: https://github.com/camunda/connector-slack
+[sns connector]: https://github.com/camunda/connector-sns
+[sqs connector]: https://github.com/camunda/connector-sqs

--- a/bundle/bundle-templates.sh
+++ b/bundle/bundle-templates.sh
@@ -17,9 +17,11 @@ wget -i - << EOF
 https://github.com/camunda/connector-aws-lambda/releases/download/${AWS_LAMBDA_VERSION}/aws-lambda-connector.json
 https://github.com/camunda/connector-google-drive/releases/download/${GOOGLE_DRIVE_VERSION}/google-drive-connector.json
 https://github.com/camunda/connector-http-json/releases/download/${HTTP_JSON_VERSION}/http-json-connector.json
+https://github.com/camunda/connector-rabbitmq/releases/download/${RABBITMQ_VERSION}/rabbitmq-connector.json
 https://github.com/camunda/connector-sendgrid/releases/download/${SENDGRID_VERSION}/sendgrid-connector.json
 https://github.com/camunda/connector-slack/releases/download/${SLACK_VERSION}/slack-connector.json
 https://github.com/camunda/connector-sqs/releases/download/${SQS_VERSION}/aws-sqs-connector.json
+https://github.com/camunda/connector-sns/releases/download/${SNS_VERSION}/aws-sns-connector.json
 EOF
 
 tag_version() {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,25 @@
+# Camunda 8 Connector Runtime
+
+This project provides a base Docker image including the [Spring Zeebe Connector runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime). 
+The image starts the job worker runtime with all `jar` files provided in the `/opt/app` directory as classpath.
+
+To use the image at least one Connector has to be added to the classpath. We recommend to provide jars with all dependencies bundled.
+
+> :warning: As all Connectors share a single classpath, it can happen that
+> different versions of the same dependency are available which can lead to
+> conflicts. To prevent this, common dependencies like `jackson` can be shaded and
+> relocated inside the connector jar.
+
+Example adding a Connector JAR by extending the image
+
+```dockerfile
+FROM camunda/connectors:0.3.0
+
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+```
+
+Example adding a Connector JAR by using volumes
+
+```bash
+docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.3.0
+```


### PR DESCRIPTION
## Description

Bumps to SDK `0.3.0` and related Connectors.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/203

