### PR TITLE
ci: generalize `actions/add-to-project` version

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -16,7 +16,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@82f0eaddf3c8f781ece8cc1164d06d24d5f28ad0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/camunda/projects/23/views/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Generalize `actions/add-to-project` version.

This will reduce noise in the release changelog.

