### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -173,6 +173,24 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle-saas:latest
 
+    # Update README in Dockerhub
+
+      - name: Push README to Dockerhub - bundle-default
+        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          destination_container_repo: camunda/connectors-bundle
+          provider: dockerhub
+          readme_file: bundle/README.md
+
+      - name: Push README to Dockerhub - bundle-saas
+        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          destination_container_repo: camunda/connectors-bundle-saas
+          provider: dockerhub
+          readme_file: bundle/README.md
+
     # Create GitHub release
 
       - name: Bundle element templates

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Release Artifacts and Docker Images
+name: Release a new version
 
 on:
   workflow_dispatch:
@@ -9,21 +9,9 @@ on:
       nextVersion:
         description: 'Semantic version number to use as next SNAPSHOT version: ^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9.-]+){0,1}$'
         required: true
-      release-runtime:
-        description: 'Release the Docker image for Connector Runtime'
-        type: boolean
-        default: true
-      release-bundle:
-        description: 'Release the Docker image for Connectors Bundle'
-        type: boolean
-        default: true
       branch:
-        description: 'Git branch of Dockerfile to be used in the release'
+        description: 'Git branch to be used in the release'
         default: 'main'
-      push-latest:
-        description: 'Push docker image with latest tag, i.e. this is the latest stable version released'
-        type: boolean
-        default: true
 
 jobs:
   build-and-push:
@@ -101,6 +89,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Check if new version implies pre-release
+        id: check_prerelease
+        run: |
+          if [[ ${{ github.event.inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            PRE_RELEASE=false
+          else
+            PRE_RELEASE=true
+          fi
+          echo "isPreRelease=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+
     # Maven build & version bump
 
       - name: Set Connectors release version
@@ -144,7 +142,6 @@ jobs:
     # Build & push bundle docker images (with version tag)
 
       - name: Build and Push Docker Image tag ${{ github.event.inputs.version }} - bundle-default
-        if: github.event.inputs.release-bundle == 'true'
         uses: docker/build-push-action@v3
         with:
           context: bundle/mvn/default-bundle/
@@ -152,7 +149,6 @@ jobs:
           tags: camunda/connectors-bundle:${{ github.event.inputs.version }}
 
       - name: Build and Push Docker Image tag ${{ github.event.inputs.version }} - bundle-saas
-        if: github.event.inputs.release-bundle == 'true'
         uses: docker/build-push-action@v3
         with:
           context: bundle/mvn/camunda-saas-bundle/
@@ -162,7 +158,7 @@ jobs:
     # Build & push bundle docker images (with 'latest' tag)
 
       - name: Build and Push Docker Image tag latest - bundle-default
-        if: github.event.inputs.release-bundle == 'true' && github.event.inputs.push-latest == 'true'
+        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
         uses: docker/build-push-action@v3
         with:
           context: bundle/mvn/default-bundle/
@@ -170,7 +166,7 @@ jobs:
           tags: camunda/connectors-bundle:latest
 
       - name: Build and Push Docker Image tag latest - bundle-saas
-        if: github.event.inputs.release-bundle == 'true' && github.event.inputs.push-latest == 'true'
+        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
         uses: docker/build-push-action@v3
         with:
           context: bundle/mvn/camunda-saas-bundle/
@@ -180,7 +176,6 @@ jobs:
     # Create GitHub release
 
       - name: Bundle element templates
-        if: github.event.inputs.release-bundle == 'true'
         run: bash bundle/bundle-templates.sh ${RELEASE_VERSION}
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
@@ -195,9 +190,9 @@ jobs:
           excludeTypes: build,docs,other,style,ci
 
       - name: Create GitHub Release
-        if: github.event.inputs.release-bundle == 'true'
         uses: softprops/action-gh-release@v1
         with:
+          prerelease: ${{ steps.check_prerelease.outputs.isPreRelease }}
           body: ${{ steps.changelog.outputs.changes }}
           tag_name: ${{ github.event.inputs.version }}
           files: |

--- a/bundle/bundle-templates.sh
+++ b/bundle/bundle-templates.sh
@@ -5,7 +5,6 @@
 set -o pipefail
 
 RELEASE_VERSION=${1:-SNAPSHOT}
-eval $(sed 's/ARG/export/gp;d' Dockerfile)
 
 ARTIFACT_DIR=${PWD}
 WORKING_DIR="$(mktemp -d)"

--- a/licenses/third-party.ftl
+++ b/licenses/third-party.ftl
@@ -12,12 +12,16 @@
         <#return "https://opensource.org/licenses/Apache-2.0">
     <#elseif license == "MIT">
         <#return "https://opensource.org/licenses/MIT">
+    <#elseif license == "BSD-2-Clause">
+        <#return "https://opensource.org/licenses/BSD-2-Clause">
     <#elseif license == "BSD-3-Clause">
         <#return "https://opensource.org/licenses/BSD-3-Clause">
     <#elseif license == "EPL-2.0">
         <#return "https://www.eclipse.org/legal/epl-2.0/">
     <#elseif license == "EPL-1.0">
         <#return "https://www.eclipse.org/legal/epl-v10.html">
+    <#elseif license == "GPLv2">
+        <#return "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html">
     <#elseif license == "GPLv2 with Classpath Exception">
         <#return "https://www.gnu.org/software/classpath/license.html">
     <#elseif license == "GNU Lesser General Public License, Version 2.1">
@@ -30,6 +34,10 @@
         <#return "https://www.bouncycastle.org/licence.html">
     <#elseif license == "Go License">
         <#return "https://go.dev/LICENSE">
+    <#elseif license == "MPL 2.0">
+        <#return "https://www.mozilla.org/en-US/MPL/2.0/">
+    <#elseif license == "Public Domain, per Creative Commons CC0">
+        <#return "https://creativecommons.org/publicdomain/zero/1.0/deed.en">
     <#else>
         <#return "no known URL">
     </#if>


### PR DESCRIPTION
## Description

* Handle pre-release versions automatically (mark as pre-release in GitHub, skip uploading images with latest tag)
* Clean up `bundle-templates.sh`
* Remove extra input flags: `release-runtime`, `release-bundle`, `push-latest`
* Handle missing license URLs in THIRD_PARTY_NOTICES

## Related issues

related to #37 

