### PR TITLE
docs: adjust labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a problem and help us fix it.
-labels: "bug"
+labels: "kind:bug"
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea or general improvement.
-labels: "enhancement"
+labels: "kind:enhancement"
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/TASK.md
+++ b/.github/ISSUE_TEMPLATE/TASK.md
@@ -1,6 +1,7 @@
 ---
 name: Task
 about: Describe a generic activity we should carry out.
+labels: "kind:task"
 ---
 
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adjusting the issue templates' labels to fit the new labels.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/243

