### PR TITLE
docs: add MIT-0 license URL

### DIFF
--- a/licenses/third-party.ftl
+++ b/licenses/third-party.ftl
@@ -12,6 +12,8 @@
         <#return "https://opensource.org/licenses/Apache-2.0">
     <#elseif license == "MIT">
         <#return "https://opensource.org/licenses/MIT">
+    <#elseif license == "MIT-0">
+        <#return "https://github.com/aws/mit-0">
     <#elseif license == "BSD-2-Clause">
         <#return "https://opensource.org/licenses/BSD-2-Clause">
     <#elseif license == "BSD-3-Clause">


### PR DESCRIPTION
## Description
Fixes 'no known URL' issue in THIRD_PARTY_NOTICES
see https://github.com/camunda/connectors-bundle/pull/39#issuecomment-1344352145


