### PR TITLE
ci: add version to release run name

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -1,4 +1,5 @@
 name: Release a new version
+run-name: Release a new version ${{ inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

Add the version to the run name of the release workflow.

## Related issues

n/a
