### PR TITLE
ci: deactivate dockerhub readme updates

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -174,23 +174,23 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle-saas:latest
 
-    # Update README in Dockerhub
+    # Update README in Dockerhub - LOGIN NOT WORKING YET (cannot reuse docker/login-action)
 
-      - name: Push README to Dockerhub - bundle-default
-        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
-        uses: christian-korneck/update-container-description-action@v1
-        with:
-          destination_container_repo: camunda/connectors-bundle
-          provider: dockerhub
-          readme_file: bundle/README.md
+#      - name: Push README to Dockerhub - bundle-default
+#        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
+#        uses: christian-korneck/update-container-description-action@v1
+#        with:
+#          destination_container_repo: camunda/connectors-bundle
+#          provider: dockerhub
+#          readme_file: bundle/README.md
 
-      - name: Push README to Dockerhub - bundle-saas
-        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
-        uses: christian-korneck/update-container-description-action@v1
-        with:
-          destination_container_repo: camunda/connectors-bundle-saas
-          provider: dockerhub
-          readme_file: bundle/README.md
+#      - name: Push README to Dockerhub - bundle-saas
+#        if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
+#        uses: christian-korneck/update-container-description-action@v1
+#        with:
+#          destination_container_repo: camunda/connectors-bundle-saas
+#          provider: dockerhub
+#          readme_file: bundle/README.md
 
     # Create GitHub release
 


### PR DESCRIPTION
## Description

Deactivate Dockerhub readme updates, as login does not work yet (cannot reuse docker/login action).

## Related issues

n/a