### PR TITLE
chore(logging): Fixed logging dependencies and added test for Spring …

### DIFF
--- a/bundle/mvn/camunda-saas-bundle/pom.xml
+++ b/bundle/mvn/camunda-saas-bundle/pom.xml
@@ -16,13 +16,6 @@
 
   <dependencies>
     <dependency>
-        <!-- Workaround for https://github.com/camunda/team-connectors/issues/251 to enforce proper version
-        Can be removed as soon as spring-zeebe >= 8.1.9 is released
-        -->
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-scala_3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.camunda.connector</groupId>
       <artifactId>connector-runtime-bundle</artifactId>
       <version>${project.version}</version>
@@ -43,12 +36,28 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.4.5</version>
+      <version>1.2.11</version>
+      <!-- enforce logback version to avoid conflicts with GCP Logging.
+           Use Spring Boot version, see https://stackoverflow.com/questions/3737992/noclassdeffounderror-org-slf4j-impl-staticloggerbinder
+           -->
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>spring-cloud-gcp-starter-logging</artifactId>
       <version>${version.spring-cloud-gcp-starter-logging}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <version>${spring-boot.version}</version>
     </dependency>
   </dependencies>
 

--- a/bundle/mvn/camunda-saas-bundle/src/main/resources/logback-spring.xml
+++ b/bundle/mvn/camunda-saas-bundle/src/main/resources/logback-spring.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="com/google/cloud/spring/logging/logback-appender.xml"/>
-    <include resource="com/google/cloud/spring/logging/logback-json-appender.xml"/>
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
-
-    <root level="INFO">
-        <!--   Use CONSOLE_JSON when running on GCP, for local testing use CONSOLE -->
-        <appender-ref ref="${CAMUNDA_SAAS_LOG_APPENDER:-CONSOLE_JSON}"/>
-    </root>
+    <springProfile name="!dev">
+        <include resource="com/google/cloud/spring/logging/logback-appender.xml"/>
+        <include resource="com/google/cloud/spring/logging/logback-json-appender.xml"/>
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </root>
+    </springProfile>
+    <springProfile name="dev">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/bundle/mvn/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/TestSpringContextStartup.java
+++ b/bundle/mvn/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/TestSpringContextStartup.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(
+    classes = SaaSConnectorRuntimeApplication.class,
+    properties = {"camunda.saas.secrets.projectId=42", "camunda.connector.polling.enabled=false"})
+@ActiveProfiles("dev")
+public class TestSpringContextStartup {
+
+  @Test
+  public void contextLoaded() {
+    // This test case just verifies that the runtime comes up without problems around
+    // conflicting class files in logging or other wired behavior that can be observed
+    // when the Spring context is initialized (e.g. https://github.com/camunda/team-connectors/issues/251)
+  }
+}

--- a/bundle/mvn/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/TestSpringContextStartup.java
+++ b/bundle/mvn/camunda-saas-bundle/src/test/java/io/camunda/connector/runtime/TestSpringContextStartup.java
@@ -30,6 +30,7 @@ public class TestSpringContextStartup {
   public void contextLoaded() {
     // This test case just verifies that the runtime comes up without problems around
     // conflicting class files in logging or other wired behavior that can be observed
-    // when the Spring context is initialized (e.g. https://github.com/camunda/team-connectors/issues/251)
+    // when the Spring context is initialized (e.g.
+    // https://github.com/camunda/team-connectors/issues/251)
   }
 }


### PR DESCRIPTION
The new test will create a Spring context to find obvious problems during build time. 
Closes https://github.com/camunda/team-connectors/issues/251.

Also ironed out the logging profile - `dev` will log to local console - everything else use GCP stuff as default.