### PR TITLE
Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/camunda/connectors-bundle/actions/workflows/DEPLOY.yaml/badge.svg)](https://github.com/camunda/connectors-bundle/actions/workflows/DEPLOY.yml)
 
-This repository manages the [out-of-the-box Connectors](./connectors) provided by Camunda. 
+This repository manages the [out-of-the-box Connectors](./connectors) provided by Camunda.
 For more information on those Connectors, refer to the
 [Camunda 8 documentation](https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/available-connectors-overview/).
 

--- a/bundle/mvn/camunda-saas-bundle/src/main/resources/application.properties
+++ b/bundle/mvn/camunda-saas-bundle/src/main/resources/application.properties
@@ -2,7 +2,7 @@ server.port=8080
 
 management.server.port=9080
 management.context-path=/actuator
-management.endpoints.web.exposure.include=metrics,health
+management.endpoints.web.exposure.include=metrics,health,prometheus
 
 cloud.gcp.logging.enabled=true
 

--- a/bundle/mvn/default-bundle/pom.xml
+++ b/bundle/mvn/default-bundle/pom.xml
@@ -18,6 +18,10 @@
       <!-- TODO: rm this dep from parent when all connectors are transferred to mono repo -->
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/bundle/mvn/default-bundle/src/test/resources/application.properties
+++ b/bundle/mvn/default-bundle/src/test/resources/application.properties
@@ -2,3 +2,7 @@
 server.port=9898
 zeebe.broker.gateway-address=localhost:26500
 zeebe.client.security.plaintext=true
+
+management.server.port=9080
+management.context-path=/actuator
+management.endpoints.web.exposure.include=metrics,health,prometheus

--- a/bundle/mvn/pom.xml
+++ b/bundle/mvn/pom.xml
@@ -29,6 +29,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>io.camunda.connector</groupId>
         <artifactId>connector-sqs</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
Add prometheus support via Spring Boot Actuator, so that Metrics can be scraped in Prometheus format under http://localhost:8080/actuator/prometheus or http://localhost:9080/actuator/prometheus depending on the port configured