### PR TITLE
ci: don't set assignee in TPL PR

### DIFF
--- a/.github/workflows/THIRD_PARTY_NOTICE.yaml
+++ b/.github/workflows/THIRD_PARTY_NOTICE.yaml
@@ -34,6 +34,5 @@ jobs:
           delete-branch: true
           commit-message: 'docs: update third-party notice'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          assignees: ${{ github.actor }}
           title: 'docs: update third-party notice'
           body: Adjust the third-party notice file


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Don't set the `assignee` in the TPL PR that is created. This fails for `renovate[bot]` for example and is not necessary either.

## Related issues

<!-- Which issues are closed by this PR or are related -->
n/a
