### PR TITLE
chore: bump spring-zeebe version to 8.1.13

### DIFF
--- a/bundle/mvn/pom.xml
+++ b/bundle/mvn/pom.xml
@@ -13,7 +13,7 @@
   </parent>
 
   <properties>
-    <spring-zeebe.version>8.1.12</spring-zeebe.version>
+    <spring-zeebe.version>8.1.13</spring-zeebe.version>
     <spring-boot.version>2.7.6</spring-boot.version>
     <connector.version>0.4.0</connector.version>
 


### PR DESCRIPTION
## Description

Spring Zeebe version 8.1.13 is necessary for the new patch release.

