### PR TITLE
Add GitHub dispatch connector

### DIFF
--- a/connectors/github-dispatch/README.md
+++ b/connectors/github-dispatch/README.md
@@ -1,0 +1,4 @@
+# GitHub Dispatch Connector
+
+Connect with the GitHub API to [trigger a webhook `repository_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch). Customizes REST Connector to send an appropriate POST request to the correct endpoint, as documented [here](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event).
+

--- a/connectors/github-dispatch/element-templates/github-dispatch-connector.json
+++ b/connectors/github-dispatch/element-templates/github-dispatch-connector.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "GitHub Dispatch Connector",
+  "id": "io.camunda.connectors.GithubDispatch.v1",
+  "description": "Send a GitHub webhook repository_dispatch event",
+  "icon":{
+    "contents":"data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 1024 1024' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z' transform='scale(64)' fill='%231B1F23'/%3E%3C/svg%3E"
+  },
+  "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/rest/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:Task"
+  ],
+  "elementType": {
+    "value": "bpmn:ServiceTask"
+  },
+  "groups": [
+    {
+      "id": "authentication",
+      "label": "Authentication"
+    },
+    {
+      "id": "endpoint",
+      "label": "Dispatch Endpoint"
+    },
+    {
+      "id": "input",
+      "label": "Payload"
+    },
+    {
+      "id": "output",
+      "label": "Response Mapping"
+    },
+    {
+      "id": "errors",
+      "label": "Error Handling"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:http-json:1",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "label": "Type",
+      "id": "authenticationType",
+      "group": "authentication",
+      "value": "bearer",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.type"
+      }
+    },
+    {
+      "id": "method",
+      "label": "Method",
+      "group": "endpoint",
+      "type": "Hidden",
+      "value": "post",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "method"
+      }
+    },
+    {
+      "label": "URL",
+      "group": "endpoint",
+      "type": "String",
+      "description":"Endpoint to trigger a 'repository_dispatch' webhook event. Replace owner and repo with your details.",
+      "feel": "optional",
+      "value":"https://api.github.com/repos/<owner>/<repo>/dispatches",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "url"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(=|https?://).*",
+          "message": "Must be a http(s) URL."
+        }
+      }
+    },
+    {
+      "label": "HTTP Headers",
+      "group": "endpoint",
+      "type": "Hidden",
+      "value": "{&#10; &#34;Accept&#34;: &#34;application/vnd.github.everest-preview+json&#34;&#10;}",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "headers"
+      }
+    },
+    {
+      "label": "Github Personal Token",
+      "group": "authentication",
+      "description": "GitHub Personal Token, needs repository and workflow scope.",
+      "type": "String",
+      "feel": "optional",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "authentication.token"
+      },
+      "constraints": {
+        "notEmpty": true
+      },
+      "condition": {
+        "property": "authenticationType",
+        "equals": "bearer"
+      }
+    },
+    {
+      "label": "Request Body",
+      "description": "Define the dispatch payload. The 'event_type' is to describe the activity type. Any data that you send through the 'client_payload' parameter will be available in the github.event context in your GitHub workflow.",
+      "group": "input",
+      "type": "Text",
+      "value":"{\"event_type\": \"EVENT_TYPE_NAME\", \"client_payload\": {} }",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "body"
+      }
+    },
+    {
+      "label": "Result Variable",
+      "description": "Name of variable to store the response in",
+      "group": "output",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultVariable"
+      }
+    },
+    {
+      "label": "Result Expression",
+      "description": "Expression to map the response into process variables",
+      "group": "output",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "resultExpression"
+      }
+    },
+    {
+      "label": "Error Expression",
+      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
+      "group": "errors",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "errorExpression"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

_Followed @tmetzke [advise](https://camunda.slack.com/archives/C03FSDF615Y/p1671821069627449?thread_ts=1671806828.754459&cid=C03FSDF615Y) and created a new connector based on the REST connector. I hope this was the correct approach to create here the PR. Please advise if not._

Created a new Connector based on the REST connector to make it easier to write a GitHub connector, which allows triggering a webhook repository_dispatch event. This allows us to connect with GitHub workflows and automate more, as we can now trigger builds, E2E, QA, etc. via Camunda 8.

![template](https://user-images.githubusercontent.com/2758593/209766946-055c9b3f-f8ee-4cc8-9118-a60ec95ce1ee.png)


Read more here https://medium.com/@zelldon91/connecting-camunda-platform-8-with-github-workflows-ee1f91488ad3

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

