### PR TITLE
chore(build): add maven shade plugin where missing

### DIFF
--- a/connectors/aws-lambda/pom.xml
+++ b/connectors/aws-lambda/pom.xml
@@ -40,21 +40,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorawslambda.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/google-drive/pom.xml
+++ b/connectors/google-drive/pom.xml
@@ -59,6 +59,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorgoogledrive.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/google-drive/pom.xml
+++ b/connectors/google-drive/pom.xml
@@ -54,21 +54,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorgoogledrive.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/http-json/pom.xml
+++ b/connectors/http-json/pom.xml
@@ -64,23 +64,6 @@ limitations under the License.</license.inlineheader>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorhttpjson.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>cloud-function-plain</id>

--- a/connectors/http-json/pom.xml
+++ b/connectors/http-json/pom.xml
@@ -69,6 +69,14 @@ limitations under the License.</license.inlineheader>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorhttpjson.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -44,21 +44,4 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorkafka.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -49,6 +49,14 @@ except in compliance with the proprietary license.</license.inlineheader>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorkafka.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -50,6 +50,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorteams.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -45,21 +45,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorteams.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -73,6 +73,24 @@ except in compliance with the proprietary license.</license.inlineheader>
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <!-- common relocation for all OOTB connectors -->
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connector.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>cloud-function</id>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -48,6 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorrabbitmq.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -43,21 +43,4 @@
 
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorrabbitmq.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -47,6 +47,14 @@ except in compliance with the proprietary license.</license.inlineheader>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorsendgrid.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/sendgrid/pom.xml
+++ b/connectors/sendgrid/pom.xml
@@ -42,21 +42,4 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorsendgrid.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -50,6 +50,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml.jackson</pattern>
+              <shadedPattern>connectorslack.com.fasterxml.jackson</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -45,21 +45,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorslack.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/sns/pom.xml
+++ b/connectors/sns/pom.xml
@@ -47,21 +47,4 @@ except in compliance with the proprietary license.</license.inlineheader>
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorsns.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/connectors/sqs/pom.xml
+++ b/connectors/sqs/pom.xml
@@ -36,21 +36,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <relocations>
-            <relocation>
-              <pattern>com.fasterxml.jackson</pattern>
-              <shadedPattern>connectorsqs.com.fasterxml.jackson</shadedPattern>
-            </relocation>
-          </relocations>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
## Description

Maven Shade plugin config is missing in most connectors, which leads to failures during classpath bundling (without Maven)

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/team-connectors/issues/258

