### PR TITLE
fix(build): fix module order to re-enable central upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
   </properties>
 
   <modules>
+    <module>connector-archetype-internal</module>
     <module>connectors</module>
     <module>bundle/mvn</module>
-    <module>connector-archetype-internal</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

Previous module order caused an interesting bug that resulted in artifacts not being uploaded to Maven Central.

The plugin that performs Central deployment defers the actual upload, so all artifacts that were created during the build are uploaded during the build of the last artifact.
In our case, `connector-archetype-internal` is the last module in the build order, so building it is supposed to also trigger the upload of all previously built artifacts. But we disabled the Maven Central upload for this specific module, so everything got skipped instead of just the archetype module.

