### PR TITLE
deps: bump SDK to 0.6.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
deps: bump SDK to 0.6.0-SNAPSHOT

Depends on:
- https://github.com/camunda/connector-sdk/pull/335
