### PR TITLE
fix(sqs): pass JSONs instead of key-value's in payload

### DIFF
--- a/connectors/sqs/src/main/java/io/camunda/connector/SqsConnectorFunction.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/SqsConnectorFunction.java
@@ -57,10 +57,14 @@ public class SqsConnectorFunction implements OutboundConnectorFunction {
               request.getAuthentication().getAccessKey(),
               request.getAuthentication().getSecretKey(),
               request.getQueue().getRegion());
+      String payload =
+          request.getQueue().getMessageBody() instanceof String
+              ? request.getQueue().getMessageBody().toString()
+              : gson.toJson(request.getQueue().getMessageBody());
       SendMessageRequest message =
           new SendMessageRequest()
               .withQueueUrl(request.getQueue().getUrl())
-              .withMessageBody(request.getQueue().getMessageBody().toString())
+              .withMessageBody(payload)
               .withMessageAttributes(request.getQueue().getAwsSqsNativeMessageAttributes());
       return sqsClient.sendMessage(message);
     } finally {

--- a/connectors/sqs/src/main/java/io/camunda/connector/model/QueueRequestData.java
+++ b/connectors/sqs/src/main/java/io/camunda/connector/model/QueueRequestData.java
@@ -21,8 +21,7 @@ public class QueueRequestData {
   @NotEmpty @Secret private String url;
   @NotEmpty @Secret private String region;
 
-  @NotNull
-  private Object messageBody; // we don't need to know the customer message as we will pass it as-is
+  @NotNull private Object messageBody;
 
   private Map<String, SqsMessageAttribute> messageAttributes;
 

--- a/connectors/sqs/src/test/java/io/camunda/connector/BaseTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/BaseTest.java
@@ -24,8 +24,7 @@ public abstract class BaseTest {
   protected static final String WRONG_MESSAGE_BODY = "its wrong msg";
   protected static final String MSG_ID = "f3f7ac8f-2ff8-48a0-bb30-f220654f6a5f";
 
-  // TODO: move to proper tests
-  protected static final String DEFAULT_REQUEST_BODY =
+  protected static final String DEFAULT_REQUEST_BODY_WITH_JSON_PAYLOAD =
       "{\n"
           + "    \"authentication\":{\n"
           + "      \"secretKey\":\"XXX\",\n"
@@ -45,6 +44,29 @@ public abstract class BaseTest {
           + "      \"messageBody\":{\n"
           + "        \"data\":\"ok\"\n"
           + "      },\n"
+          + "      \"region\":\"us-east-1\",\n"
+          + "      \"url\":\"https://sqs.us-east-1.amazonaws.com/0000000/test-test-test\"\n"
+          + "    }\n"
+          + "  }";
+
+  protected static final String DEFAULT_REQUEST_BODY_WITH_STRING_PAYLOAD =
+      "{\n"
+          + "    \"authentication\":{\n"
+          + "      \"secretKey\":\"XXX\",\n"
+          + "      \"accessKey\":\"YYY\"\n"
+          + "    },\n"
+          + "    \"queue\":{\n"
+          + "      \"messageAttributes\":{\n"
+          + "        \"description\":{\n"
+          + "          \"StringValue\":\"delivery receipt from transaction 001122334455\",\n"
+          + "          \"DataType\":\"String\"\n"
+          + "        },\n"
+          + "        \"size\":{\n"
+          + "          \"StringValue\":\"2 KiB\",\n"
+          + "          \"DataType\":\"String\"\n"
+          + "        }\n"
+          + "      },\n"
+          + "      \"messageBody\": \"I am a string value!\",\n"
           + "      \"region\":\"us-east-1\",\n"
           + "      \"url\":\"https://sqs.us-east-1.amazonaws.com/0000000/test-test-test\"\n"
           + "    }\n"

--- a/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorFunctionParametrizedTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorFunctionParametrizedTest.java
@@ -91,7 +91,7 @@ class SqsConnectorFunctionParametrizedTest {
     SqsConnectorResult connectorResult = (SqsConnectorResult) connectorResultObject;
     assertThat(connectorResult.getMessageId()).isEqualTo(MSG_ID);
     assertThat(initialRequest.getMessageBody())
-        .isEqualTo(expectedRequest.getQueue().getMessageBody().toString());
+        .isEqualTo(GSON.toJson(expectedRequest.getQueue().getMessageBody()));
     assertThat(initialRequest.getMessageAttributes().size())
         .isEqualTo(expectedRequest.getQueue().getMessageAttributes().size());
   }

--- a/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorFunctionTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorFunctionTest.java
@@ -19,6 +19,7 @@ import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -34,7 +35,7 @@ public class SqsConnectorFunctionTest extends BaseTest {
         OutboundConnectorContextBuilder.create()
             .secret(AWS_ACCESS_KEY, ACTUAL_ACCESS_KEY)
             .secret(AWS_SECRET_KEY, ACTUAL_SECRET_KEY)
-            .variables(DEFAULT_REQUEST_BODY)
+            .variables(DEFAULT_REQUEST_BODY_WITH_JSON_PAYLOAD)
             .build();
     sendMessageResult = new SendMessageResult();
     sendMessageResult.setMessageId(MSG_ID);
@@ -76,5 +77,63 @@ public class SqsConnectorFunctionTest extends BaseTest {
     Assertions.assertThat(execute).isInstanceOf(SqsConnectorResult.class);
     var result = (SqsConnectorResult) execute;
     Assertions.assertThat(result.getMessageId()).isEqualTo(MSG_ID);
+  }
+
+  @Test
+  public void execute_shouldPassPayloadAsJsonWhenJsonArrivesFromForm() {
+    // Given
+    AmazonSQS sqsClient = Mockito.mock(AmazonSQS.class);
+    Mockito.when(sqsClient.sendMessage(ArgumentMatchers.any(SendMessageRequest.class)))
+        .thenReturn(sendMessageResult);
+    SqsClientSupplier sqsClientSupplier = Mockito.mock(SqsClientSupplier.class);
+    Mockito.when(
+            sqsClientSupplier.sqsClient(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString()))
+        .thenReturn(sqsClient);
+    ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+    Mockito.when(sqsClient.sendMessage(captor.capture())).thenReturn(new SendMessageResult());
+    connector = new SqsConnectorFunction(sqsClientSupplier, GSON);
+
+    // When
+    connector.execute(context);
+
+    // Then
+    SendMessageRequest capturedRequest = captor.getValue();
+    Assertions.assertThat(capturedRequest.getMessageBody()).isEqualTo("{\"data\":\"ok\"}");
+  }
+
+  @Test
+  public void execute_shouldPassPayloadAsStringWhenStringArrivesFromForm() {
+    // Given
+    context =
+        OutboundConnectorContextBuilder.create()
+            .secret(AWS_ACCESS_KEY, ACTUAL_ACCESS_KEY)
+            .secret(AWS_SECRET_KEY, ACTUAL_SECRET_KEY)
+            .variables(DEFAULT_REQUEST_BODY_WITH_STRING_PAYLOAD)
+            .build();
+    sendMessageResult = new SendMessageResult();
+    sendMessageResult.setMessageId(MSG_ID);
+    AmazonSQS sqsClient = Mockito.mock(AmazonSQS.class);
+    Mockito.when(sqsClient.sendMessage(ArgumentMatchers.any(SendMessageRequest.class)))
+        .thenReturn(sendMessageResult);
+    SqsClientSupplier sqsClientSupplier = Mockito.mock(SqsClientSupplier.class);
+    Mockito.when(
+            sqsClientSupplier.sqsClient(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString()))
+        .thenReturn(sqsClient);
+    ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+    Mockito.when(sqsClient.sendMessage(captor.capture())).thenReturn(new SendMessageResult());
+    connector = new SqsConnectorFunction(sqsClientSupplier, GSON);
+
+    // When
+    connector.execute(context);
+
+    // Then
+    SendMessageRequest capturedRequest = captor.getValue();
+    Assertions.assertThat(capturedRequest.getMessageBody()).isEqualTo("I am a string value!");
   }
 }

--- a/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorRequestTest.java
+++ b/connectors/sqs/src/test/java/io/camunda/connector/SqsConnectorRequestTest.java
@@ -26,7 +26,7 @@ class SqsConnectorRequestTest extends BaseTest {
 
   @BeforeEach
   public void beforeEach() {
-    request = GSON.fromJson(DEFAULT_REQUEST_BODY, SqsConnectorRequest.class);
+    request = GSON.fromJson(DEFAULT_REQUEST_BODY_WITH_JSON_PAYLOAD, SqsConnectorRequest.class);
 
     context =
         OutboundConnectorContextBuilder.create()


### PR DESCRIPTION
## Description

Point to be confirmed: backward compatibility.

Pass JSONs instead of key-value's in payload.

## Related issues

- Related to https://jira.camunda.com/browse/SUPPORT-15656

closes # TBD

