### PR TITLE
chore(docs, element templates): add documentation references to Result Mapping

### DIFF
--- a/connectors/aws-lambda/element-templates/aws-lambda-connector.json
+++ b/connectors/aws-lambda/element-templates/aws-lambda-connector.json
@@ -138,7 +138,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Enter name of variable to store the response in",
+      "description": "Enter name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -148,7 +148,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/google-drive/element-templates/google-drive-connector.json
+++ b/connectors/google-drive/element-templates/google-drive-connector.json
@@ -271,7 +271,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Enter name of variable to store the response in",
+      "description": "Enter name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -281,7 +281,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/http-json/element-templates/http-json-connector.json
+++ b/connectors/http-json/element-templates/http-json-connector.json
@@ -360,7 +360,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -370,7 +370,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/kafka/element-templates/kafka-connector.json
+++ b/connectors/kafka/element-templates/kafka-connector.json
@@ -137,7 +137,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -147,7 +147,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
+++ b/connectors/microsoft-teams/element-templates/microsoft-teams-connector.json
@@ -742,7 +742,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Enter the name of the variable where the response should be stored",
+      "description": "Enter the name of the variable where the response should be stored. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -752,7 +752,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/rabbitmq/element-templates/rabbitmq-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-connector.json
@@ -226,7 +226,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Enter name of variable to store the response in",
+      "description": "Enter name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -236,7 +236,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/slack/element-templates/slack-connector.json
+++ b/connectors/slack/element-templates/slack-connector.json
@@ -218,7 +218,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -228,7 +228,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/sns/element-templates/aws-sns-connector.json
+++ b/connectors/sns/element-templates/aws-sns-connector.json
@@ -143,7 +143,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -153,7 +153,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",

--- a/connectors/sqs/element-templates/aws-sqs-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-connector.json
@@ -128,7 +128,7 @@
     },
     {
       "label": "Result Variable",
-      "description": "Name of variable to store the response in",
+      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "String",
       "binding": {
@@ -138,7 +138,7 @@
     },
     {
       "label": "Result Expression",
-      "description": "Expression to map the response into process variables",
+      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
       "group": "output",
       "type": "Text",
       "feel": "required",


### PR DESCRIPTION
## Description

chore(docs, element templates): add documentation references to Result Mapping

## Related issues

- https://github.com/camunda/connectors-bundle/issues/158

