### PR TITLE
chore: moved java execution to start.sh

### DIFF
--- a/bundle/mvn/default-bundle/Dockerfile
+++ b/bundle/mvn/default-bundle/Dockerfile
@@ -4,5 +4,7 @@ RUN mkdir /opt/app
 # Download connectors from maven central
 COPY target/*-with-dependencies.jar /opt/app/
 
-# Using entry point to allow downstream images to add JVM arguments using CMD
-ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.ConnectorRuntimeApplication"]
+COPY start.sh /start.sh
+RUN chmod +x start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/bundle/mvn/default-bundle/start.sh
+++ b/bundle/mvn/default-bundle/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+JAVA_OPTS="${JAVA_OPTS}"
+
+# Explicitly set trust store location
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTORE}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVAX_NET_SSL_TRUSTSTORE}"
+fi
+
+# Explicitly set trust store password
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}"
+fi
+
+if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
+  echo "Applied JVM options: $JAVA_OPTS"
+fi
+
+exec java ${JAVA_OPTS} -cp /opt/app/* io.camunda.connector.runtime.ConnectorRuntimeApplication


### PR DESCRIPTION
## Description

chore: moved java execution to start.sh

The Docker `ENTRYPOINT` in exec-mode does not allow to pass environment variables thus reworked it to enter from shell while preserving entripoint in exec-mode.

Preserving exec mode is required, since we wish to allow docker to manage zeebe and operate IP addresses.

## Related issues

- https://github.com/camunda/camunda-platform/pull/82

closes #108

