### PR TITLE
fix(gdrive): forced parent folder ID as optional

### DIFF
--- a/connectors/google-drive/element-templates/google-drive-connector.json
+++ b/connectors/google-drive/element-templates/google-drive-connector.json
@@ -217,6 +217,7 @@
       "group": "operationDetails",
       "type": "String",
       "feel": "optional",
+      "optional": true,
       "binding": {
         "type": "zeebe:input",
         "name": "resource.parent"
@@ -232,6 +233,7 @@
       "group": "operationDetails",
       "type": "String",
       "feel": "optional",
+      "optional": true,
       "binding": {
         "type": "zeebe:input",
         "name": "resource.parent"


### PR DESCRIPTION
## Description

Forced parent folder ID as optional.

## Related

- https://forum.camunda.io/t/google-drive-connector/42163

