### PR TITLE
chore(ci): use CI Nexus as a mirror

### DIFF
--- a/.github/workflows/DEPLOY.yaml
+++ b/.github/workflows/DEPLOY.yaml
@@ -50,7 +50,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Build Artifacts
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy

--- a/.github/workflows/DEPLOY.yaml
+++ b/.github/workflows/DEPLOY.yaml
@@ -39,6 +39,19 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+
       - name: Build Artifacts
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy
         env:

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -77,7 +77,7 @@ jobs:
                "passphrase": "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}",
              }
             ]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Configure git user
         run: |

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -56,33 +56,28 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Create ~/.m2/settings.xml
-        shell: bash
-        run: |
-          cat <<EOF > ~/.m2/settings.xml
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-            <interactiveMode>false</interactiveMode>
-            <servers>
-              <server>
-                <id>camunda-nexus</id>
-                <username>\${env.NEXUS_USR}</username>
-                <password>\${env.NEXUS_PSW}</password>
-              </server>
-              <server>
-                <id>central</id>
-                <username>\${env.MAVEN_USR}</username>
-                <password>\${env.MAVEN_PSW}</password>
-              </server>
-              <server>
-                <id>gpg.passphrase</id>
-                <passphrase>\${env.MAVEN_GPG_PASSPHRASE}</passphrase>
-              </server>
-            </servers>
-          </settings>
-          EOF
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             },
+            {
+               "id": "gpg.passphrase",
+               "passphrase": "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}",
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - name: Configure git user
         run: |

--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -42,7 +42,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -12,11 +12,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
           cache: 'maven'
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/THIRD_PARTY_NOTICE.yaml
+++ b/.github/workflows/THIRD_PARTY_NOTICE.yaml
@@ -45,7 +45,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Create individual notice files (per connector/bundle)
         run: mvn org.codehaus.mojo:license-maven-plugin:add-third-party -Dlicense.excludedGroups=io.camunda -Dlicense.fileTemplate="licenses/third-party.ftl"

--- a/.github/workflows/THIRD_PARTY_NOTICE.yaml
+++ b/.github/workflows/THIRD_PARTY_NOTICE.yaml
@@ -14,12 +14,38 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Import Secrets
+        id: secrets # important to refer to it in later steps
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
       - name: Prepare Java and Maven settings
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - name: Create individual notice files (per connector/bundle)
         run: mvn org.codehaus.mojo:license-maven-plugin:add-third-party -Dlicense.excludedGroups=io.camunda -Dlicense.fileTemplate="licenses/third-party.ftl"


### PR DESCRIPTION
## Description

Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/327

