### PR TITLE
deps: bump SDK version to 0.6.0 and Spring Zeebe version to 8.1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>0.6.0-alpha4</version>
+    <version>0.6.0</version>
     <relativePath/>
   </parent>
 
@@ -19,7 +19,7 @@
   <inceptionYear>2022</inceptionYear>
 
   <properties>
-    <version.spring-zeebe>8.1.16</version.spring-zeebe>
+    <version.spring-zeebe>8.1.17</version.spring-zeebe>
 
     <version.spring-boot>2.7.8</version.spring-boot>
     <version.spring-cloud-gcp-starter-logging>3.4.4</version.spring-cloud-gcp-starter-logging>


### PR DESCRIPTION
## Description

Bump SDK version to 0.6.0 and Spring Zeebe version to 8.1.17

## Related issues

https://github.com/camunda/team-connectors/issues/330

closes #

