### PR TITLE
feat(docker): add multiplatform build

### DIFF
--- a/.github/workflows/DEPLOY.yaml
+++ b/.github/workflows/DEPLOY.yaml
@@ -68,6 +68,11 @@ jobs:
         with:
           dockerfile: bundle/mvn/default-bundle/Dockerfile
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
@@ -84,6 +89,7 @@ jobs:
           context: bundle/mvn/default-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle:SNAPSHOT
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and Push Docker Image tag SNAPSHOT - bundle-saas
         uses: docker/build-push-action@v4
@@ -91,3 +97,4 @@ jobs:
           context: bundle/mvn/camunda-saas-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle-saas:SNAPSHOT
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -122,6 +122,11 @@ jobs:
         env:
           NEXT_VERSION: ${{ github.event.inputs.nextVersion }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
+
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v2
 
@@ -139,6 +144,7 @@ jobs:
           context: bundle/mvn/default-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle:${{ github.event.inputs.version }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and Push Docker Image tag ${{ github.event.inputs.version }} - bundle-saas
         uses: docker/build-push-action@v4
@@ -146,6 +152,7 @@ jobs:
           context: bundle/mvn/camunda-saas-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle-saas:${{ github.event.inputs.version }}
+          platforms: linux/amd64,linux/arm64
 
     # Build & push bundle docker images (with 'latest' tag)
 
@@ -156,6 +163,7 @@ jobs:
           context: bundle/mvn/default-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle:latest
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and Push Docker Image tag latest - bundle-saas
         if: ${{ steps.check_prerelease.outputs.isPreRelease == 'false' }}
@@ -164,6 +172,7 @@ jobs:
           context: bundle/mvn/camunda-saas-bundle/
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: camunda/connectors-bundle-saas:latest
+          platforms: linux/amd64,linux/arm64
 
     # Update README in Dockerhub
 


### PR DESCRIPTION
## Description

Enables multiplatform build for amd64 and arm64 platforms by using QEMU emulator.

Already tested and [published under  `SNAPSHOT` tag](https://hub.docker.com/r/camunda/connectors-bundle-saas/tags) - feel free to check it out!

References:
- https://github.com/camunda/docker-camunda-bpm-platform/pull/237
- https://blog.thesparktree.com/docker-multi-arch-github-actions

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #308 

