### PR TITLE
fix(inbound): add element type to inbound connector templates

### DIFF
--- a/connectors/github/element-templates/github-webhook-connector.json
+++ b/connectors/github/element-templates/github-webhook-connector.json
@@ -12,6 +12,9 @@
   "appliesTo":[
     "bpmn:StartEvent"
   ],
+  "elementType": {
+    "value": "bpmn:StartEvent"
+  },
   "groups":[
     {
       "id":"endpoint",

--- a/connectors/webhook-connector/element-templates/webhook-connector.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector.json
@@ -12,6 +12,9 @@
   "appliesTo": [
     "bpmn:StartEvent"
   ],
+  "elementType": {
+    "value": "bpmn:StartEvent"
+  },
   "groups": [
     {
       "id": "endpoint",


### PR DESCRIPTION
## Description

This PR explicitly defines `elementType` in our inbound webhook connector templates.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #335 

