### PR TITLE
chore(webhook): rename webhook template type

### DIFF
--- a/connectors/github/element-templates/github-webhook-connector.json
+++ b/connectors/github/element-templates/github-webhook-connector.json
@@ -32,7 +32,7 @@
   "properties":[
     {
       "type":"Hidden",
-      "value":"webhook",
+      "value":"io.camunda:webhook:1",
       "binding":{
         "type":"zeebe:property",
         "name":"inbound.type"

--- a/connectors/webhook-connector/element-templates/webhook-connector.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector.json
@@ -32,7 +32,7 @@
   "properties": [
     {
       "type": "Hidden",
-      "value": "webhook",
+      "value": "io.camunda:webhook:1",
       "binding": {
         "type": "zeebe:property",
         "name": "inbound.type"


### PR DESCRIPTION
## Description

Webhook type was renamed from `webhook` to `io.camunda:webhook:1` to match the pattern we have for outbound.



