### PR TITLE
feat(release): add fromTag for changelog generation

### DIFF
--- a/.github/workflows/RELEASE.yaml
+++ b/.github/workflows/RELEASE.yaml
@@ -7,6 +7,9 @@ on:
       version:
         description: 'Semantic version number of release: ^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9.-]+){0,1}$'
         required: true
+      prevVersion:
+        description: 'Previous release tag for correct changelog generation.'
+        required: true
       nextVersion:
         description: 'Semantic version number to use as next SNAPSHOT version: ^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9.-]+){0,1}$'
         required: true
@@ -216,7 +219,8 @@ jobs:
         uses: Requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
-          tag: ${{ github.event.inputs.version }}
+          fromTag: ${{ github.event.inputs.prevVersion }}
+          toTag: ${{ github.event.inputs.version }}
           writeToFile: false
           excludeTypes: build,docs,other,style,ci
 


### PR DESCRIPTION
## Description

Allows to build changelog from a specified tag. Previously we couldn't generate a correct changelog when there were pre-releases in between the 'normal' releases.


