### PR TITLE
Small fixes to Operate and OpenAI element templates

### DIFF
--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -11,9 +11,7 @@
     "id": "connectors",
     "name": "Connectors"
   },
-  "appliesTo": [
-    "bpmn:Task"
-  ],
+  "appliesTo": ["bpmn:Task"],
   "elementType": {
     "value": "bpmn:ServiceTask"
   },
@@ -318,6 +316,7 @@
       "group": "output",
       "type": "Text",
       "feel": "required",
+      "value": "={openAiResponse: response.body}",
       "binding": {
         "type": "zeebe:taskHeader",
         "key": "resultExpression"

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Camunda Operate Connector",
-  "id": "io.camunda.connector.CamundaOperate.v1",
+  "id": "io.camunda.connectors.CamundaOperate.v1",
   "description": "Fetch data from Camunda Operate API",
-  "appliesTo": [
-    "bpmn:Task"
-  ],
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/operate/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": ["bpmn:Task"],
   "elementType": {
     "value": "bpmn:ServiceTask"
   },


### PR DESCRIPTION
## Description

Fixed minor issues in Operate and OpenAI connector templates:
- Missing connector group (operate)
- Missing documentation ref (operate)
- Wrong connector ID pattern (operate)
- Missing sample result expression (openai)

