### PR TITLE
fix(rest): relax regex check for URL to allow placeholders

### DIFF
--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/model/CommonRequest.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/model/CommonRequest.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.Pattern;
 public class CommonRequest {
 
   @NotBlank
-  @Pattern(regexp = "^(http://|https://|secrets).*$")
+  @Pattern(regexp = "^(http://|https://|secrets|\\{\\{).*$")
   @Secret
   private String url;
 

--- a/connectors/graphql/src/test/java/io/camunda/connector/graphql/GraphQLFunctionInputValidationTest.java
+++ b/connectors/graphql/src/test/java/io/camunda/connector/graphql/GraphQLFunctionInputValidationTest.java
@@ -81,7 +81,7 @@ public class GraphQLFunctionInputValidationTest extends BaseTest {
     assertThat(exception.getMessage())
         .contains(
             "Found constraints violated while validating input",
-            "must match \"^(http://|https://|secrets).*$\"");
+            "must match \"^(http://|https://|secrets|\\{\\{).*$\"");
   }
 
   @ParameterizedTest(name = "Validate null field # {index}")

--- a/connectors/http-json/src/test/java/io/camunda/connector/http/BaseTest.java
+++ b/connectors/http-json/src/test/java/io/camunda/connector/http/BaseTest.java
@@ -70,6 +70,7 @@ public class BaseTest {
 
   protected interface ActualValue {
     String URL = "https://camunda.io/http-endpoint";
+    String URL_WITH_PATH = "https://camunda.io/http-endpoint/path";
     String METHOD = "GET";
     String CONNECT_TIMEOUT = "50";
 

--- a/connectors/http-json/src/test/java/io/camunda/connector/http/HttpJsonFunctionInputValidationTest.java
+++ b/connectors/http-json/src/test/java/io/camunda/connector/http/HttpJsonFunctionInputValidationTest.java
@@ -90,7 +90,7 @@ public class HttpJsonFunctionInputValidationTest extends BaseTest {
     assertThat(exception.getMessage())
         .contains(
             "Found constraints violated while validating input",
-            "must match \"^(http://|https://|secrets).*$\"");
+            "must match \"^(http://|https://|secrets|\\{\\{).*$\"");
   }
 
   @ParameterizedTest(name = "Validate null field # {index}")

--- a/connectors/http-json/src/test/java/io/camunda/connector/http/HttpJsonFunctionSecretsTest.java
+++ b/connectors/http-json/src/test/java/io/camunda/connector/http/HttpJsonFunctionSecretsTest.java
@@ -52,7 +52,7 @@ public class HttpJsonFunctionSecretsTest extends BaseTest {
     // When
     context.replaceSecrets(httpJsonRequest);
     // Then should replace secrets
-    assertThat(httpJsonRequest.getUrl()).isEqualTo(ActualValue.URL);
+    assertThat(httpJsonRequest.getUrl()).isIn(ActualValue.URL, ActualValue.URL_WITH_PATH);
     assertThat(httpJsonRequest.getMethod()).isEqualTo(ActualValue.METHOD);
     assertThat(httpJsonRequest.getConnectionTimeoutInSeconds())
         .isEqualTo(ActualValue.CONNECT_TIMEOUT);

--- a/connectors/http-json/src/test/resources/requests/success-cases-replace-secrets.json
+++ b/connectors/http-json/src/test/resources/requests/success-cases-replace-secrets.json
@@ -103,5 +103,53 @@
       },
       "text": "{{secrets.TEXT_PART_1_KEY}}{{secrets.TEXT_PART_2_KEY}}{{secrets.TEXT_PART_3_KEY}}"
     }
+  },
+  {
+    "url": "{{secrets.URL_KEY}}",
+    "method": "secrets.METHOD_KEY",
+    "authentication": {
+      "type": "noAuth"
+    },
+    "queryParameters": {
+      "q": "secrets.QUERY_PARAMETER_KEY",
+      "priority": "secrets.PRIORITY_KEY"
+    },
+    "headers": {
+      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
+      "User-Agent": "secrets.USER_AGENT_KEY"
+    },
+    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "body": {
+      "customer": {
+        "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
+        "name": "{{secrets.NAME_KEY}} plus some text",
+        "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
+      },
+      "text": "secrets.TEXT_KEY"
+    }
+  },
+  {
+    "url": "{{secrets.URL_KEY}}/path",
+    "method": "secrets.METHOD_KEY",
+    "authentication": {
+      "type": "noAuth"
+    },
+    "queryParameters": {
+      "q": "secrets.QUERY_PARAMETER_KEY",
+      "priority": "secrets.PRIORITY_KEY"
+    },
+    "headers": {
+      "X-Camunda-Cluster-ID": "secrets.CLUSTER_ID_KEY",
+      "User-Agent": "secrets.USER_AGENT_KEY"
+    },
+    "connectionTimeoutInSeconds":"secrets.CONNECT_TIMEOUT_KEY",
+    "body": {
+      "customer": {
+        "id": "startId plus {{secrets.CUSTOMER_ID_KEY}}",
+        "name": "{{secrets.NAME_KEY}} plus some text",
+        "email": "start email plus {{secrets.EMAIL_KEY}} plus end email"
+      },
+      "text": "secrets.TEXT_KEY"
+    }
   }
 ]


### PR DESCRIPTION
## Description

fix(rest): relax regex check for URL to allow placeholders.

closes #411

## Testing done

Given secret: `export HTTP_BIN_URL_FULL=https://httpbin.org/anything/anything`

<img width="626" alt="Screenshot 2023-03-29 at 19 03 48" src="https://user-images.githubusercontent.com/108870003/228599422-94a0ad76-3084-47f6-b130-bcfc18642026.png">

![Screenshot 2023-03-29 at 19 04 16](https://user-images.githubusercontent.com/108870003/228599429-05020600-7da6-4fc0-8492-5522ed0e0cb7.png)

---

<img width="637" alt="Screenshot 2023-03-29 at 19 03 32" src="https://user-images.githubusercontent.com/108870003/228599496-0b6acb1a-448c-43f8-aaba-4142f3649160.png">

![Screenshot 2023-03-29 at 19 03 23](https://user-images.githubusercontent.com/108870003/228599489-9cbc547c-975b-4693-808c-53a5d65c2003.png)

