### PR TITLE
fix(docs): Property `queue.messageGroupId` is required for FIFO queues.

### DIFF
--- a/connectors/sqs/element-templates/aws-sqs-connector.json
+++ b/connectors/sqs/element-templates/aws-sqs-connector.json
@@ -140,6 +140,9 @@
         "property": "queue.type",
         "equals": "fifo"
       },
+      "constraints": {
+        "notEmpty": true
+      },
       "feel": "optional"
     },
     {


### PR DESCRIPTION
## Description

The `queue.messageGroupId` is now required for FIFO queues.

## Related issues

closes camunda/team-connectors/issues/368

