### PR TITLE
allows predefined headers for graphql connector

### DIFF
--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPProxyService.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPProxyService.java
@@ -25,6 +25,8 @@ import com.google.gson.Gson;
 import io.camunda.connector.common.constants.Constants;
 import io.camunda.connector.common.model.CommonRequest;
 import io.camunda.connector.common.model.HttpRequestBuilder;
+import org.apache.http.protocol.HttpService;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -54,6 +56,7 @@ public final class HTTPProxyService {
             .content(content)
             .connectionTimeoutInSeconds(request.getConnectionTimeoutInSeconds())
             .followRedirects(false)
+            .headers(HTTPService.extractRequestHeaders(request))
             .build(requestFactory);
 
     ProxyOAuthHelper.addOauthHeaders(

--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPService.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPService.java
@@ -22,6 +22,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
+import com.google.common.collect.Collections2;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +65,18 @@ public class HTTPService {
       }
       request.getAuthentication().setHeaders(httpHeaders);
     }
+    httpHeaders.putAll(extractRequestHeaders(request));
     return httpHeaders;
+  }
+
+  public static HttpHeaders extractRequestHeaders(final CommonRequest commonRequest) {
+    if (commonRequest.hasHeaders()) {
+      final HttpHeaders httpHeaders = new HttpHeaders();
+      commonRequest.getHeaders().forEach(httpHeaders::set);
+      return httpHeaders;
+    }
+
+    return new HttpHeaders();
   }
 
   public HttpResponse executeHttpRequest(HttpRequest externalRequest) throws IOException {

--- a/connectors/graphql/element-templates/graphql-connector.json
+++ b/connectors/graphql/element-templates/graphql-connector.json
@@ -121,6 +121,17 @@
       }
     },
     {
+      "id": "headers",
+      "label": "Headers",
+      "group": "endpoint",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:input",
+        "name": "graphql.headers"
+      }
+    },
+    {
       "label": "Query/Mutation",
       "description": "See <a href=\"https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/graphql/#querymutation\" target=\"_blank\">documentation</a>",
       "group": "graphql",

--- a/connectors/graphql/src/main/java/io/camunda/connector/graphql/GraphQLFunction.java
+++ b/connectors/graphql/src/main/java/io/camunda/connector/graphql/GraphQLFunction.java
@@ -115,10 +115,10 @@ public class GraphQLFunction implements OutboundConnectorFunction {
 
   private CommonResult executeGraphQLConnectorViaProxy(GraphQLRequest request) throws IOException {
     CommonRequest commonRequest = GraphQLRequestMapper.toCommonRequest(request);
+    HTTPService httpService = new HTTPService(gson);
+
     HttpRequest httpRequest =
         HTTPProxyService.toRequestViaProxy(gson, requestFactory, commonRequest, proxyFunctionUrl);
-
-    HTTPService httpService = new HTTPService(gson);
 
     HttpResponse httpResponse = httpService.executeHttpRequest(httpRequest, true);
 

--- a/connectors/graphql/src/test/resources/requests/success-test-cases.json
+++ b/connectors/graphql/src/test/resources/requests/success-test-cases.json
@@ -84,5 +84,24 @@
         "id": "cGVvcGxlOjI="
       }
     }
+  },
+  {
+    "descriptionOfTest": "Normal request with custom headers",
+    "authentication": {
+      "type": "noAuth"
+    },
+    "graphql": {
+      "method": "get",
+      "url": "https://camunda.io/http-endpoint",
+      "connectionTimeoutInSeconds": "50",
+      "query": "query Root($id: ID) {\n  person (id: $id) {\n    id\n    name\n  }\n}",
+      "variables": {
+        "id": "cGVvcGxlOjI="
+      },
+      "headers": {
+        "custom-header-1": "custom-header-value-1",
+        "custom-header-2": "custom-header-value-2"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Description

Enhance the GraphQL connector by adding the option to define custom http headers from the modeler and add them to the http request

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/connectors-bundle/issues/477

