### PR TITLE
feat: webhook intermediate event template

### DIFF
--- a/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Webhook Connector",
+  "id": "io.camunda.connectors.webhook.WebhookConnectorIntermediate.v1",
+  "version": 1,
+  "description": "Configure webhook to receive callbacks",
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
+  "category": {
+    "id": "connectors",
+    "name": "Connectors"
+  },
+  "appliesTo": [
+    "bpmn:IntermediateCatchEvent",
+    "bpmn:IntermediateThrowEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:IntermediateCatchEvent",
+    "eventDefinition": "bpmn:MessageEventDefinition"
+  },
+  "groups": [
+    {
+      "id": "endpoint",
+      "label": "Webhook Configuration"
+    },
+    {
+      "id": "activation",
+      "label": "Activation"
+    },
+    {
+      "id": "variable-mapping",
+      "label": "Variable Mapping"
+    }
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "io.camunda:webhook:1",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.type"
+      }
+    },
+    {
+      "type": "Hidden",
+      "generatedValue": {
+        "type": "uuid"
+      },
+      "binding": {
+        "type": "bpmn:Message#property",
+        "name": "name"
+      }
+    },
+    {
+      "type": "Hidden",
+      "value": "ConfigurableInboundWebhook",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.subtype"
+      }
+    },
+    {
+      "label": "Webhook ID",
+      "type": "String",
+      "group": "endpoint",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.context"
+      },
+      "description": "The webhook ID is a part of the URL"
+    },
+    {
+      "id": "shouldValidateHmac",
+      "label": "HMAC Authentication",
+      "group": "endpoint",
+      "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
+      "value": "disabled",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Enabled",
+          "value": "enabled"
+        },
+        {
+          "name": "Disabled",
+          "value": "disabled"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.shouldValidateHmac"
+      }
+    },
+    {
+      "label": "HMAC Secret Key",
+      "description": "Shared secret key",
+      "type": "String",
+      "group": "endpoint",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacSecret"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "HMAC Header",
+      "description": "Name of header attribute that will contain the HMAC value",
+      "type": "String",
+      "group": "endpoint",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacHeader"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "HMAC Algorithm",
+      "group": "endpoint",
+      "description": "Choose HMAC algorithm",
+      "value": "sha_256",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "SHA-1",
+          "value": "sha_1"
+        },
+        {
+          "name": "SHA-256",
+          "value": "sha_256"
+        },
+        {
+          "name": "SHA-512",
+          "value": "sha_512"
+        }
+      ],
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.hmacAlgorithm"
+      },
+      "condition": {
+        "property": "shouldValidateHmac",
+        "equals": "enabled"
+      }
+    },
+    {
+      "label": "Correlation key (process)",
+      "type": "String",
+      "group": "activation",
+      "feel": "optional",
+      "description": "Sets up the correlation key from process variables.",
+      "binding": {
+        "type": "bpmn:Message#zeebe:subscription#property",
+        "name": "correlationKey"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Correlation key expression (payload)",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "correlationKeyExpression"
+      },
+      "description": "Extracts the correlation key from the incoming message payload.",
+      "constraints": {
+        "notEmpty": true
+      }
+    },
+    {
+      "label": "Condition",
+      "type": "String",
+      "group": "activation",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.activationCondition"
+      },
+      "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    },
+    {
+      "label": "Variables",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.variableMapping"
+      },
+      "description": "Map variables from the webhook payload (request) to start the process with. When blank, entire payload is copied over. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+    }
+  ],
+  "icon": {
+    "contents": "data:image/svg+xml,%3Csvg id='icon' xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 32 32'%3E%3Cdefs%3E%3Cstyle%3E .cls-1 %7B fill: none; %7D %3C/style%3E%3C/defs%3E%3Cpath d='M24,26a3,3,0,1,0-2.8164-4H13v1a5,5,0,1,1-5-5V16a7,7,0,1,0,6.9287,8h6.2549A2.9914,2.9914,0,0,0,24,26Z'/%3E%3Cpath d='M24,16a7.024,7.024,0,0,0-2.57.4873l-3.1656-5.5395a3.0469,3.0469,0,1,0-1.7326.9985l4.1189,7.2085.8686-.4976a5.0006,5.0006,0,1,1-1.851,6.8418L17.937,26.501A7.0005,7.0005,0,1,0,24,16Z'/%3E%3Cpath d='M8.532,20.0537a3.03,3.03,0,1,0,1.7326.9985C11.74,18.47,13.86,14.7607,13.89,14.708l.4976-.8682-.8677-.497a5,5,0,1,1,6.812-1.8438l1.7315,1.002a7.0008,7.0008,0,1,0-10.3462,2.0356c-.457.7427-1.1021,1.8716-2.0737,3.5728Z'/%3E%3Crect id='_Transparent_Rectangle_' data-name='&lt;Transparent Rectangle&gt;' class='cls-1' width='32' height='32'/%3E%3C/svg%3E"
+  }
+}

--- a/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
@@ -70,7 +70,7 @@
     },
     {
       "id": "shouldValidateHmac",
-      "label": "HMAC Authentication",
+      "label": "HMAC authentication",
       "group": "endpoint",
       "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
@@ -91,7 +91,7 @@
       }
     },
     {
-      "label": "HMAC Secret Key",
+      "label": "HMAC secret key",
       "description": "Shared secret key",
       "type": "String",
       "group": "endpoint",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "label": "HMAC Header",
+      "label": "HMAC header",
       "description": "Name of header attribute that will contain the HMAC value",
       "type": "String",
       "group": "endpoint",
@@ -121,7 +121,7 @@
       }
     },
     {
-      "label": "HMAC Algorithm",
+      "label": "HMAC algorithm",
       "group": "endpoint",
       "description": "Choose HMAC algorithm",
       "value": "sha_256",
@@ -153,8 +153,8 @@
       "label": "Correlation key (process)",
       "type": "String",
       "group": "activation",
-      "feel": "optional",
-      "description": "Sets up the correlation key from process variables.",
+      "feel": "required",
+      "description": "Sets up the correlation key from process variables",
       "binding": {
         "type": "bpmn:Message#zeebe:subscription#property",
         "name": "correlationKey"
@@ -172,7 +172,7 @@
         "type": "zeebe:property",
         "name": "correlationKeyExpression"
       },
-      "description": "Extracts the correlation key from the incoming message payload.",
+      "description": "Extracts the correlation key from the incoming message payload",
       "constraints": {
         "notEmpty": true
       }

--- a/connectors/webhook-connector/element-templates/webhook-connector.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector.json
@@ -58,7 +58,7 @@
     },
     {
       "id": "shouldValidateHmac",
-      "label": "HMAC Authentication",
+      "label": "HMAC authentication",
       "group": "endpoint",
       "description": "Choose whether HMAC verification is enabled. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a> and <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#example' target='_blank'>example</a> that explains how to use HMAC-related fields",
       "value": "disabled",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "label": "HMAC Secret Key",
+      "label": "HMAC secret key",
       "description": "Shared secret key",
       "type": "String",
       "group": "endpoint",
@@ -94,7 +94,7 @@
       }
     },
     {
-      "label": "HMAC Header",
+      "label": "HMAC header",
       "description": "Name of header attribute that will contain the HMAC value",
       "type": "String",
       "group": "endpoint",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "label": "HMAC Algorithm",
+      "label": "HMAC algorithm",
       "group": "endpoint",
       "description": "Choose HMAC algorithm",
       "value": "sha_256",


### PR DESCRIPTION
## Description

Added 2 correlation key fields to the `Activation` group:

<img width="397" alt="Screenshot 2023-05-03 at 17 30 32" src="https://user-images.githubusercontent.com/38818382/235964415-e5c12d8a-73a5-4f65-bdaa-cff4af4307fd.png">

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/product-hub/issues/817

