### PR TITLE
fix: use spring-boot-3-style autoconfiguration

### DIFF
--- a/bundle/default-bundle/pom.xml
+++ b/bundle/default-bundle/pom.xml
@@ -76,7 +76,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <mainClass>io.camunda.connector.runtime.ConnectorRuntimeApplication</mainClass>
+          <mainClass>io.camunda.connector.bundle.ConnectorRuntimeApplication</mainClass>
         </configuration>
       </plugin>
        <plugin>
@@ -131,7 +131,7 @@
                   <resource>META-INF/io.netty.versions.properties</resource>
               </transformer>
               <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                <mainClass>io.camunda.connector.runtime.ConnectorRuntimeApplication</mainClass>
+                <mainClass>io.camunda.connector.bundle.ConnectorRuntimeApplication</mainClass>
               </transformer>
             </transformers>
           </configuration>

--- a/bundle/default-bundle/src/main/java/io/camunda/connector/bundle/ConnectorRuntimeApplication.java
+++ b/bundle/default-bundle/src/main/java/io/camunda/connector/bundle/ConnectorRuntimeApplication.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.runtime;
+package io.camunda.connector.bundle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -1,13 +1,19 @@
+
+server.port=9898
+zeebe.broker.gateway-address=localhost:26500
+zeebe.client.security.plaintext=true
+
 camunda.connector.polling.enabled=true
 camunda.connector.polling.interval=5000
 
 camunda.connector.webhook.enabled=true
-#spring.main.web-application-type=none
 
-# uncomment to activate inbound and adjust operate config if necessary
-#operate.client.enabled=true
+operate.client.enabled=true
 # Operate config for use with docker-compose-core.yml
-#camunda.operate.client.url=http://localhost:8081
-#camunda.operate.client.username=demo
-#camunda.operate.client.password=demo
-#camunda.connector.webhook.enabled=true
+camunda.operate.client.url=http://localhost:8081
+camunda.operate.client.username=demo
+camunda.operate.client.password=demo
+camunda.connector.webhook.enabled=true
+
+logging.level.io.camunda.connector=trace
+debug=true

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -14,6 +14,3 @@ camunda.operate.client.url=http://localhost:8081
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 camunda.connector.webhook.enabled=true
-
-logging.level.io.camunda.connector=trace
-debug=true

--- a/bundle/default-bundle/src/test/resources/application.properties
+++ b/bundle/default-bundle/src/test/resources/application.properties
@@ -15,5 +15,3 @@ camunda.operate.client.url=http://localhost:8081
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 camunda.connector.webhook.enabled=true
-
-logging.level.io.camunda.connector=trace

--- a/spring-boot-starter-camunda-connectors/README.md
+++ b/spring-boot-starter-camunda-connectors/README.md
@@ -167,14 +167,14 @@ It uses the default configuration specified through the `@OutboundConnector` ann
 
 ```bash
 java -cp 'connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+    io.camunda.connector.bundle.ConnectorRuntimeApplication
 ```
 
 Note that you need to use `;` instead of `:` on Windows machines:
 
 ```bash
 java -cp 'connector-runtime-VERSION-with-dependencies.jar;connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+    io.camunda.connector.bundle.ConnectorRuntimeApplication
 ```
 
 #### Manual Discovery
@@ -195,7 +195,7 @@ CONNECTOR_HTTPJSON_FUNCTION=io.camunda.connector.http.HttpJsonFunction
 CONNECTOR_HTTPJSON_TYPE=non-default-httpjson-task-type
 
 java -cp 'connector-runtime-VERSION-with-dependencies.jar:connector-http-json-VERSION-with-dependencies.jar' \
-    io.camunda.connector.runtime.ConnectorRuntimeApplication
+    io.camunda.connector.bundle.ConnectorRuntimeApplication
 ```
 
 ### Secrets

--- a/spring-boot-starter-camunda-connectors/pom.xml
+++ b/spring-boot-starter-camunda-connectors/pom.xml
@@ -77,7 +77,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <mainClass>io.camunda.connector.runtime.ConnectorRuntimeApplication</mainClass>
+          <mainClass>io.camunda.connector.bundle.ConnectorRuntimeApplication</mainClass>
         </configuration>
       </plugin>
       <plugin>
@@ -147,7 +147,7 @@
             </transformer>
             <transformer
               implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>io.camunda.connector.runtime.ConnectorRuntimeApplication</mainClass>
+              <mainClass>io.camunda.connector.bundle.ConnectorRuntimeApplication</mainClass>
             </transformer>
           </transformers>
         </configuration>

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.connector.runtime.env.SpringSecretProvider;
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
@@ -34,11 +35,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class ConnectorsAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean
   public SecretProvider springSecretProvider(Environment environment) {
     return new SpringSecretProvider(environment);
   }
 
   @Bean
+  @ConditionalOnMissingBean
   public ConnectorPropertyResolver springConnectorPropertyResolver(Environment environment) {
     return new SpringConnectorPropertyResolver(environment);
   }

--- a/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starter-camunda-connectors/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.camunda.connector.runtime.ConnectorsAutoConfiguration

--- a/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
+++ b/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
@@ -29,5 +29,3 @@ operate.client.enabled=true
 #camunda.operate.client.client-secret=xxx
 
 # See io.camunda.connector.inbound.operate.OperateClientFactory for more details on config Options
-
-debug=true


### PR DESCRIPTION
## Description

Minor adjustments to support the new auto-configuration registration pattern defined in Spring Boot 3 (see [migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration)). The auto-configuration needs to be defined in a different file now. I also kept the old file to keep it potentially compatible with spring boot 2.


