### PR TITLE
557: fix(rabbitmq): remove auth data from tostring

### DIFF
--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqAuthentication.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqAuthentication.java
@@ -82,18 +82,6 @@ public class RabbitMqAuthentication {
 
   @Override
   public String toString() {
-    return "RabbitMqAuthentication{"
-        + "authType="
-        + authType
-        + ", userName='"
-        + userName
-        + "'"
-        + ", password='"
-        + password
-        + "'"
-        + ", uri='"
-        + uri
-        + "'"
-        + "}";
+    return "RabbitMqAuthentication{" + "authType=" + authType + "}";
   }
 }


### PR DESCRIPTION
## Description

Removes sensitive data from `toString`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #557 

