### PR TITLE
fix: minor element template adjustments

### DIFF
--- a/connectors/github/element-templates/github-webhook-connector-intermediate.json
+++ b/connectors/github/element-templates/github-webhook-connector-intermediate.json
@@ -144,15 +144,27 @@
       "description":"Condition under which the connector triggers. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
     },
     {
-      "label":"Variables",
-      "type":"String",
-      "group":"variable-mapping",
-      "feel":"required",
-      "binding":{
-        "type":"zeebe:property",
-        "name":"inbound.variableMapping"
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
       },
-      "description":"Variables extracted from the webhook payload (request) to start the process with. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
+      "description": "Name of variable to store the result of the Connector in"
+    },
+    {
+      "label":"Result expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
     }
   ],
   "icon":{

--- a/connectors/github/element-templates/github-webhook-connector-start-event.json
+++ b/connectors/github/element-templates/github-webhook-connector-start-event.json
@@ -104,7 +104,7 @@
       "description":"Condition under which the connector triggers. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
     },
     {
-      "label": "Result Variable",
+      "label": "Result variable",
       "type": "String",
       "group": "variable-mapping",
       "optional": true,
@@ -115,7 +115,7 @@
       "description": "Name of variable to store the result of the Connector in"
     },
     {
-      "label":"Result Expression",
+      "label":"Result expression",
       "type": "String",
       "group": "variable-mapping",
       "feel": "required",

--- a/connectors/github/element-templates/github-webhook-connector-start-event.json
+++ b/connectors/github/element-templates/github-webhook-connector-start-event.json
@@ -2,7 +2,7 @@
   "$schema":"https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name":"GitHub Webhook Connector",
   "id":"io.camunda.connectors.webhook.GithubWebhookConnector.v1",
-  "version":1,
+  "version":2,
   "description":"Receive events from GitHub",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/",
   "category":{
@@ -104,15 +104,27 @@
       "description":"Condition under which the connector triggers. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
     },
     {
-      "label":"Variables",
-      "type":"String",
-      "group":"variable-mapping",
-      "feel":"required",
-      "binding":{
-        "type":"zeebe:property",
-        "name":"inbound.variableMapping"
+      "label": "Result Variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
       },
-      "description":"Variables extracted from the webhook payload (request) to start the process with. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/github-webhook/' target='_blank'>See documentation</a>"
+      "description": "Name of variable to store the result of the Connector in"
+    },
+    {
+      "label":"Result Expression",
+      "type": "String",
+      "group": "variable-mapping",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
     }
   ],
   "icon":{

--- a/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector-intermediate.json
@@ -244,19 +244,8 @@
       "type": "Text",
       "feel": "required",
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultExpression"
-      }
-    },
-    {
-      "label": "Error expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
-      "group": "errors",
-      "type": "Text",
-      "feel": "required",
-      "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "errorExpression"
+        "type": "zeebe:property",
+        "name": "resultExpression"
       }
     }
   ],

--- a/connectors/kafka/element-templates/kafka-inbound-connector.json
+++ b/connectors/kafka/element-templates/kafka-inbound-connector.json
@@ -204,19 +204,8 @@
       "type": "Text",
       "feel": "required",
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultExpression"
-      }
-    },
-    {
-      "label": "Error expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
-      "group": "errors",
-      "type": "Text",
-      "feel": "required",
-      "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "errorExpression"
+        "type": "zeebe:property",
+        "name": "resultExpression"
       }
     }
   ],

--- a/connectors/rabbitmq/element-templates/rabbitmq-start-event-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-start-event-connector.json
@@ -240,7 +240,7 @@
       "description": "Condition under which the Connector triggers. Leave empty to catch all events"
     },
     {
-      "label": "Result Variable",
+      "label": "Result variable",
       "type": "String",
       "group": "variable-mapping",
       "optional": true,
@@ -251,7 +251,7 @@
       "description": "Name of variable to store the result of the Connector in"
     },
     {
-      "label":"Result Expression",
+      "label":"Result expression",
       "type": "String",
       "group": "variable-mapping",
       "feel": "required",

--- a/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
@@ -190,7 +190,7 @@
       "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
-      "label": "Result Variable",
+      "label": "Result variable",
       "type": "String",
       "group": "variable-mapping",
       "optional": true,
@@ -201,7 +201,7 @@
       "description": "Name of variable to store the result of the Connector in"
     },
     {
-      "label":"Result Expression",
+      "label":"Result expression",
       "type": "String",
       "group": "variable-mapping",
       "feel": "required",

--- a/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector-intermediate.json
@@ -190,15 +190,27 @@
       "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
-      "label": "Variables",
+      "label": "Result Variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the Connector in"
+    },
+    {
+      "label":"Result Expression",
       "type": "String",
       "group": "variable-mapping",
       "feel": "required",
+      "optional": true,
       "binding": {
         "type": "zeebe:property",
-        "name": "inbound.variableMapping"
+        "name": "resultExpression"
       },
-      "description": "Map variables from the webhook payload (request) to start the process with. When blank, entire payload is copied over. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Expression to map the inbound payload to process variables"
     }
   ],
   "icon": {

--- a/connectors/webhook-connector/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook-connector/element-templates/webhook-connector-start-event.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook Connector",
   "id": "io.camunda.connectors.webhook.WebhookConnector.v1",
-  "version": 1,
+  "version": 2,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {
@@ -150,15 +150,27 @@
       "description": "Condition under which the connector triggers. Leave empty to catch all events. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
     },
     {
-      "label": "Variables",
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "resultVariable"
+      },
+      "description": "Name of variable to store the result of the Connector in"
+    },
+    {
+      "label":"Result expression",
       "type": "String",
       "group": "variable-mapping",
       "feel": "required",
+      "optional": true,
       "binding": {
         "type": "zeebe:property",
-        "name": "inbound.variableMapping"
+        "name": "resultExpression"
       },
-      "description": "Map variables from the webhook payload (request) to start the process with. When blank, entire payload is copied over. <a href='https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/#make-your-http-webhook-connector-for-receiving-messages-executable' target='_blank'>See documentation</a>"
+      "description": "Expression to map the inbound payload to process variables"
     }
   ],
   "icon": {


### PR DESCRIPTION
## Description

* Migrates webhook element template to the new result handling fields (`resultVariable`/`resultExpression` instead of a legacy `variableMapping` field)
* Fixes a copy-paste error in the kafka element templates

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #559 

