### PR TITLE
feat(sns-inbound): added sns inbound

### DIFF
--- a/connectors/sns/element-templates/aws-sns-inbound-start-event.json
+++ b/connectors/sns/element-templates/aws-sns-inbound-start-event.json
@@ -1,176 +1,138 @@
 {
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
-  "name": "Amazon SNS Connector",
-  "id": "io.camunda.connectors.AWSSNS.v1",
-  "description": "Send message to topic",
-  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sns/",
+  "name": "SNS HTTPS Subscription",
+  "id": "io.camunda.connectors.inbound.AWSSNS.StartEvent.v1",
+  "description": "Receive events from AWS SNS",
   "version": 1,
-  "appliesTo": [
-    "bpmn:Task"
-  ],
-  "elementType": {
-    "value": "bpmn:ServiceTask"
-  },
+  "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sns/",
   "category": {
     "id": "connectors",
     "name": "Connectors"
   },
+  "appliesTo": [
+    "bpmn:StartEvent"
+  ],
+  "elementType": {
+    "value": "bpmn:StartEvent"
+  },
   "groups": [
     {
-      "id": "authentication",
-      "label": "Authentication"
+      "id": "subscription",
+      "label": "Subscription Configuration"
     },
     {
-      "id": "topicProperties",
-      "label": "Topic properties"
+      "id": "activation",
+      "label": "Activation"
     },
     {
-      "id": "output",
-      "label": "Output"
-    },
-    {
-      "id": "input",
-      "label": "Input message data"
-    },
-    {
-      "id": "errors",
-      "label": "Error Handling"
+      "id": "variable-mapping",
+      "label": "Variable Mapping"
     }
   ],
   "properties": [
     {
-      "type": "Hidden",
-      "value": "io.camunda:aws-sns:1",
-      "binding": {
-        "type": "zeebe:taskDefinition:type"
+      "type":"Hidden",
+      "value":"io.camunda:aws-sns-inbound:1",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.type"
       }
     },
     {
-      "label": "Access Key",
-      "description": "Provide AWS IAM access key that has permission to publish to desired SNS topic",
-      "group": "authentication",
-      "type": "String",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "authentication.accessKey"
+      "type":"Hidden",
+      "value":"SnsHttpsSubscription",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.subtype"
+      }
+    },
+    {
+      "label":"Subscription ID",
+      "type":"String",
+      "group":"subscription",
+      "binding":{
+        "type":"zeebe:property",
+        "name":"inbound.context"
       },
+      "description":"The subscription ID is a part of the URL endpoint",
       "constraints": {
         "notEmpty": true
       }
     },
     {
-      "label": "Secret Key",
-      "description": "Provide AWS IAM secret key that has permission to publish to desired SNS topic",
-      "group": "authentication",
-      "type": "String",
+      "id": "securitySubscriptionAllowedFor",
+      "label": "Allow to receive messages from topic(s)",
+      "group": "subscription",
+      "description": "Control which topic(s) is allowed to start a process",
+      "value": "any",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "Any",
+          "value": "any"
+        },
+        {
+          "name": "Specific topic(s)",
+          "value": "specific"
+        }
+      ],
       "binding": {
-        "type": "zeebe:input",
-        "name": "authentication.secretKey"
-      },
-      "constraints": {
-        "notEmpty": true
+        "type": "zeebe:property",
+        "name": "inbound.securitySubscriptionAllowedFor"
       }
     },
     {
-      "label": "Topic ARN",
-      "description": "Specify the topic you want to publish to",
-      "group": "topicProperties",
+      "label": "Topic ARN(s)",
+      "description": "Topics that allow to publish messages",
       "type": "String",
+      "group": "subscription",
+      "feel": "optional",
       "binding": {
-        "type": "zeebe:input",
-        "name": "topic.topicArn"
+        "type": "zeebe:property",
+        "name": "inbound.topicsAllowList"
       },
       "constraints": {
         "notEmpty": true
+      },
+      "condition": {
+        "property": "securitySubscriptionAllowedFor",
+        "equals": "specific"
       }
     },
     {
-      "label": "Region",
-      "description": "Specify the AWS region of your topic",
-      "group": "topicProperties",
+      "label": "Condition",
       "type": "String",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "topic.region"
-      },
-      "constraints": {
-        "notEmpty": true
-      },
-      "feel": "optional"
-    },
-    {
-      "label": "Subject",
-      "description": "Specify the subject of the message you want to publish in the SNS topic",
-      "group": "input",
-      "type": "String",
+      "group": "activation",
+      "feel": "required",
       "optional": true,
       "binding": {
-        "type": "zeebe:input",
-        "name": "topic.subject"
+        "type": "zeebe:property",
+        "name": "activationCondition"
       },
-      "constraints": {
-        "notEmpty": false,
-        "maxLength": 99
-      },
-      "feel": "optional"
+      "description": "Condition under which the connector triggers. Leave empty to catch all events"
     },
     {
-      "label": "Message",
-      "description": "Data to publish in the SNS topic",
-      "group": "input",
-      "type": "Text",
-      "binding": {
-        "type": "zeebe:input",
-        "name": "topic.message"
-      },
-      "constraints": {
-        "notEmpty": true
-      },
-      "feel": "optional"
-    },
-    {
-      "label": "Message attributes",
-      "description": "Message attributes metadata",
-      "group": "input",
-      "type": "Text",
+      "label": "Result variable",
+      "type": "String",
+      "group": "variable-mapping",
       "optional": true,
       "binding": {
-        "type": "zeebe:input",
-        "name": "topic.messageAttributes"
+        "type": "zeebe:property",
+        "name": "resultVariable"
       },
-      "feel": "required"
+      "description": "Name of variable to store the result of the Connector in"
     },
     {
-      "label": "Result Variable",
-      "description": "Name of variable to store the response in. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-variable\" target=\"_blank\">documentation</a>",
-      "group": "output",
+      "label":"Result expression",
       "type": "String",
-      "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultVariable"
-      }
-    },
-    {
-      "label": "Result Expression",
-      "description": "Expression to map the response into process variables. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#result-expression\" target=\"_blank\">documentation</a>",
-      "group": "output",
-      "type": "Text",
+      "group": "variable-mapping",
       "feel": "required",
+      "optional": true,
       "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "resultExpression"
-      }
-    },
-    {
-      "label": "Error Expression",
-      "description": "Expression to handle errors. Details in the <a href=\"https://docs.camunda.io/docs/components/connectors/use-connectors/#bpmn-errors\" target=\"_blank\">documentation</a>",
-      "group": "errors",
-      "type": "Text",
-      "feel": "required",
-      "binding": {
-        "type": "zeebe:taskHeader",
-        "key": "errorExpression"
-      }
+        "type": "zeebe:property",
+        "name": "resultExpression"
+      },
+      "description": "Expression to map the inbound payload to process variables"
     }
   ],
   "icon": {

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound;
+
+import com.amazonaws.services.sns.message.SnsMessage;
+import com.amazonaws.services.sns.message.SnsMessageManager;
+import com.amazonaws.services.sns.message.SnsNotification;
+import com.amazonaws.services.sns.message.SnsSubscriptionConfirmation;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.annotation.InboundConnector;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
+import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
+import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.sns.inbound.model.SnsWebhookConnectorProperties;
+import io.camunda.connector.sns.inbound.model.SnsWebhookProcessingResult;
+import io.camunda.connector.sns.inbound.model.SubscriptionAllowListFlag;
+import io.camunda.connector.sns.suppliers.ObjectMapperSupplier;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InboundConnector(name = "SNS_INBOUND", type = "io.camunda:aws-sns-inbound:1")
+public class SnsWebhookExecutable implements WebhookConnectorExecutable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SnsWebhookExecutable.class);
+
+  protected static final String TOPIC_ARN_HEADER = "x-amz-sns-topic-arn";
+
+  private final ObjectMapper objectMapper;
+  private final SnsClientSupplier snsClientSupplier;
+
+  private SnsWebhookConnectorProperties props;
+
+  public SnsWebhookExecutable() {
+    this(ObjectMapperSupplier.getMapperInstance(), new SnsClientSupplier());
+  }
+
+  public SnsWebhookExecutable(
+      final ObjectMapper objectMapper, final SnsClientSupplier snsClientSupplier) {
+    this.objectMapper = objectMapper;
+    this.snsClientSupplier = snsClientSupplier;
+  }
+
+  @Override
+  public WebhookProcessingResult triggerWebhook(WebhookProcessingPayload webhookProcessingPayload)
+      throws Exception {
+    checkMessageAllowListed(webhookProcessingPayload);
+    Map bodyAsMap = objectMapper.readValue(webhookProcessingPayload.rawBody(), Map.class);
+    String region = extractRegionFromTopicArnHeader(webhookProcessingPayload.headers());
+    SnsMessageManager msgManager = snsClientSupplier.messageManager(region);
+    SnsMessage msg =
+        msgManager.parseMessage(new ByteArrayInputStream(webhookProcessingPayload.rawBody()));
+    if (msg instanceof SnsSubscriptionConfirmation ssc) {
+      return tryConfirmSubscription(webhookProcessingPayload, bodyAsMap, ssc);
+    } else if (msg instanceof SnsNotification) {
+      return handleNotification(webhookProcessingPayload, bodyAsMap);
+    } else {
+      throw new IOException("Operation not supported: " + msg.getClass().getName());
+    }
+  }
+
+  private SnsWebhookProcessingResult tryConfirmSubscription(
+      WebhookProcessingPayload webhookProcessingPayload,
+      Map bodyAsMap,
+      SnsSubscriptionConfirmation confirmation) {
+    // If request was tampered, or insufficient ACL, confirmation will throw an exception
+    confirmation.confirmSubscription();
+
+    return new SnsWebhookProcessingResult(
+        bodyAsMap,
+        webhookProcessingPayload.headers(),
+        webhookProcessingPayload.params(),
+        Map.of("snsEventType", "Subscription"));
+  }
+
+  private SnsWebhookProcessingResult handleNotification(
+      WebhookProcessingPayload webhookProcessingPayload, Map bodyAsMap) {
+    return new SnsWebhookProcessingResult(
+        bodyAsMap,
+        webhookProcessingPayload.headers(),
+        webhookProcessingPayload.params(),
+        Map.of("snsEventType", "Notification"));
+  }
+
+  private void checkMessageAllowListed(WebhookProcessingPayload webhookProcessingPayload)
+      throws Exception {
+    if (SubscriptionAllowListFlag.specific.equals(props.getSubscriptionAllowListFlag())
+        && !props
+            .getSubscriptionAllowList()
+            .contains(webhookProcessingPayload.headers().get(TOPIC_ARN_HEADER))) {
+      throw new Exception(
+          "Request didn't match allow list. Allow list: "
+              + props.getSubscriptionAllowList()
+              + ". Request coming from "
+              + webhookProcessingPayload.headers().get(TOPIC_ARN_HEADER));
+    }
+  }
+
+  @Override
+  public void activate(InboundConnectorContext context) throws Exception {
+    if (context == null) {
+      throw new Exception("Inbound connector context cannot be null");
+    }
+    props = new SnsWebhookConnectorProperties(context.getProperties());
+    context.replaceSecrets(props);
+  }
+
+  // Topic ARN header has a format arn:aws:sns:region-xyz:000011112222:TopicName, and
+  // we need to extract region from it, which is at index 3, given string is separated by ':'
+  private String extractRegionFromTopicArnHeader(final Map<String, String> headers)
+      throws Exception {
+    final var topicArn =
+        Optional.ofNullable(headers.get(TOPIC_ARN_HEADER))
+            .orElseThrow(
+                () -> new Exception("SNS request did not contain header: " + TOPIC_ARN_HEADER));
+    return topicArn.split(":")[3];
+  }
+}

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookConnectorProperties.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound.model;
+
+import io.camunda.connector.api.annotation.Secret;
+import io.camunda.connector.impl.inbound.InboundConnectorProperties;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class SnsWebhookConnectorProperties {
+
+  private final InboundConnectorProperties genericProperties;
+  @Secret private String context;
+  private SubscriptionAllowListFlag subscriptionAllowListFlag;
+  @Secret private List<String> subscriptionAllowList;
+
+  public SnsWebhookConnectorProperties(InboundConnectorProperties properties) {
+    this.genericProperties = properties;
+    this.context = genericProperties.getProperties().get("inbound.context");
+    // If no value somehow passed, force it to specific.
+    // In this case, BPMN process might fail but at the same time, we enforce security.
+    this.subscriptionAllowListFlag =
+        SubscriptionAllowListFlag.valueOf(
+            genericProperties
+                .getProperties()
+                .getOrDefault(
+                    "inbound.securitySubscriptionAllowedFor",
+                    SubscriptionAllowListFlag.specific.name()));
+    this.subscriptionAllowList =
+        Arrays.stream(
+                genericProperties
+                    .getProperties()
+                    .getOrDefault("inbound.topicsAllowList", "")
+                    .trim()
+                    .split(","))
+            .collect(Collectors.toList());
+  }
+
+  public InboundConnectorProperties getGenericProperties() {
+    return genericProperties;
+  }
+
+  public String getContext() {
+    return context;
+  }
+
+  public SubscriptionAllowListFlag getSubscriptionAllowListFlag() {
+    return Optional.ofNullable(subscriptionAllowListFlag)
+        .orElse(SubscriptionAllowListFlag.specific);
+  }
+
+  public List<String> getSubscriptionAllowList() {
+    return Optional.ofNullable(subscriptionAllowList).orElse(Collections.emptyList());
+  }
+
+  public void setContext(String context) {
+    this.context = context;
+  }
+
+  public void setSubscriptionAllowListFlag(SubscriptionAllowListFlag subscriptionAllowListFlag) {
+    this.subscriptionAllowListFlag = subscriptionAllowListFlag;
+  }
+
+  public void setSubscriptionAllowList(List<String> subscriptionAllowList) {
+    this.subscriptionAllowList = subscriptionAllowList;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SnsWebhookConnectorProperties that = (SnsWebhookConnectorProperties) o;
+    return Objects.equals(genericProperties, that.genericProperties)
+        && Objects.equals(context, that.context)
+        && subscriptionAllowListFlag == that.subscriptionAllowListFlag
+        && Objects.equals(subscriptionAllowList, that.subscriptionAllowList);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        genericProperties, context, subscriptionAllowListFlag, subscriptionAllowList);
+  }
+
+  @Override
+  public String toString() {
+    return "SnsWebhookConnectorProperties{"
+        + "genericProperties="
+        + genericProperties
+        + ", context='"
+        + context
+        + '\''
+        + ", subscriptionAllowListFlag="
+        + subscriptionAllowListFlag
+        + ", subscriptionAllowList="
+        + subscriptionAllowList
+        + '}';
+  }
+}

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookProcessingResult.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookProcessingResult.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound.model;
+
+import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class SnsWebhookProcessingResult implements WebhookProcessingResult {
+
+  private Map<String, Object> body;
+  private Map<String, String> headers;
+  private Map<String, String> params;
+  private Map<String, Object> connectorData;
+
+  public SnsWebhookProcessingResult() {}
+
+  public SnsWebhookProcessingResult(
+      Map<String, Object> body,
+      Map<String, String> headers,
+      Map<String, String> params,
+      Map<String, Object> connectorData) {
+    this.body = body;
+    this.headers = headers;
+    this.params = params;
+    this.connectorData = connectorData;
+  }
+
+  @Override
+  public Map<String, Object> body() {
+    return Optional.ofNullable(body).orElse(Collections.emptyMap());
+  }
+
+  @Override
+  public Map<String, String> headers() {
+    return Optional.ofNullable(headers).orElse(Collections.emptyMap());
+  }
+
+  @Override
+  public Map<String, String> params() {
+    return Optional.ofNullable(params).orElse(Collections.emptyMap());
+  }
+
+  @Override
+  public Map<String, Object> connectorData() {
+    return Optional.ofNullable(connectorData).orElse(Collections.emptyMap());
+  }
+}

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SubscriptionAllowListFlag.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/inbound/model/SubscriptionAllowListFlag.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound.model;
+
+// Any means that any topic can subscribe onto this process
+// Specific means that the user has to specify explicit list of ARNs
+public enum SubscriptionAllowListFlag {
+  any,
+  specific
+}

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector;
+package io.camunda.connector.sns.outbound;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.PublishRequest;
@@ -13,10 +13,10 @@ import com.google.gson.Gson;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.model.SnsConnectorRequest;
-import io.camunda.connector.model.SnsConnectorResult;
-import io.camunda.connector.suppliers.SnsClientSupplier;
-import io.camunda.connector.suppliers.SnsGsonComponentSupplier;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
+import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
+import io.camunda.connector.sns.suppliers.SnsGsonComponentSupplier;
 import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsAuthenticationRequestData.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsAuthenticationRequestData.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.model;
+package io.camunda.connector.sns.outbound.model;
 
 import io.camunda.connector.api.annotation.Secret;
 import java.util.Objects;

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsConnectorRequest.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsConnectorRequest.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.model;
+package io.camunda.connector.sns.outbound.model;
 
 import io.camunda.connector.api.annotation.Secret;
 import java.util.Objects;

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsConnectorResult.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsConnectorResult.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.model;
+package io.camunda.connector.sns.outbound.model;
 
 import java.util.Objects;
 

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsMessageAttribute.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/SnsMessageAttribute.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.model;
+package io.camunda.connector.sns.outbound.model;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.Objects;

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.model;
+package io.camunda.connector.sns.outbound.model;
 
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import io.camunda.connector.api.annotation.Secret;

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/ObjectMapperSupplier.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/ObjectMapperSupplier.java
@@ -4,18 +4,17 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.suppliers;
+package io.camunda.connector.sns.suppliers;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-public final class SnsGsonComponentSupplier {
+public final class ObjectMapperSupplier {
 
-  private static final Gson GSON = new GsonBuilder().create();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private SnsGsonComponentSupplier() {}
+  private ObjectMapperSupplier() {}
 
-  public static Gson gsonInstance() {
-    return GSON;
+  public static ObjectMapper getMapperInstance() {
+    return MAPPER;
   }
 }

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/SnsClientSupplier.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/SnsClientSupplier.java
@@ -4,12 +4,13 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector.suppliers;
+package io.camunda.connector.sns.suppliers;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sns.message.SnsMessageManager;
 
 public class SnsClientSupplier {
 
@@ -19,5 +20,9 @@ public class SnsClientSupplier {
             new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
         .withRegion(region)
         .build();
+  }
+
+  public SnsMessageManager messageManager(final String region) {
+    return new SnsMessageManager(region);
   }
 }

--- a/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/SnsGsonComponentSupplier.java
+++ b/connectors/sns/src/main/java/io/camunda/connector/sns/suppliers/SnsGsonComponentSupplier.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.suppliers;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public final class SnsGsonComponentSupplier {
+
+  private static final Gson GSON = new GsonBuilder().create();
+
+  private SnsGsonComponentSupplier() {}
+
+  public static Gson gsonInstance() {
+    return GSON;
+  }
+}

--- a/connectors/sns/src/main/resources/META-INF/services/io.camunda.connector.api.inbound.InboundConnectorExecutable
+++ b/connectors/sns/src/main/resources/META-INF/services/io.camunda.connector.api.inbound.InboundConnectorExecutable
@@ -1,0 +1,1 @@
+io.camunda.connector.sns.inbound.SnsWebhookExecutable

--- a/connectors/sns/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
+++ b/connectors/sns/src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorFunction
@@ -1,1 +1,1 @@
-io.camunda.connector.SnsConnectorFunction
+io.camunda.connector.sns.outbound.SnsConnectorFunction

--- a/connectors/sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookExecutableTest.java
+++ b/connectors/sns/src/test/java/io/camunda/connector/sns/inbound/SnsWebhookExecutableTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.sns.inbound;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.sns.message.SnsMessageManager;
+import com.amazonaws.services.sns.message.SnsNotification;
+import com.amazonaws.services.sns.message.SnsSubscriptionConfirmation;
+import com.amazonaws.services.sns.message.SnsUnknownMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
+import io.camunda.connector.impl.inbound.InboundConnectorProperties;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SnsWebhookExecutableTest {
+
+  @Mock private InboundConnectorContext ctx;
+  @Mock private InboundConnectorProperties props;
+  @Mock private ObjectMapper mapper;
+  @Mock private SnsClientSupplier snsClientSupplier;
+  @Mock private SnsMessageManager messageManager;
+  private SnsWebhookExecutable testObject;
+
+  private final Map<String, String> snsRequestHeaders =
+      Map.of(
+          "user-agent", "Amazon Simple Notification Service Agent",
+          "content-type", "text/plain; charset=UTF-8",
+          "x-amz-sns-topic-arn", "arn:aws:sns:eu-central-1:111222333444:SNSWebhook",
+          "x-amz-sns-message-id", "b9b4574f-b4ab-4c03-ac14-a3145896747f");
+
+  private static final String SUBSCRIPTION_CONFIRMATION_REQUEST =
+      """
+                            {
+                              "Type": "SubscriptionConfirmation",
+                              "MessageId": "b9b4574f-b4ab-4c03-ac14-a3145896747f",
+                              "Token": "2336412f37fb687f5d51e6e2425c464de12884d217e7e1b25b4c24b4450f9aa05e48016238eefabedec9af616cb7ef5ce99b4971b74f7070b6375e42a1052f57240475072de0c1898fdf2871f4d5dadcecd5ac9f846e33de54818faf18d05560073594e7694509eb33acb0b6f806919b",
+                              "TopicArn": "arn:aws:sns:eu-central-1:111222333444:SNSWebhook",
+                              "Message": "You have chosen to subscribe to the topic arn:aws:sns:eu-central-1:111222333444:SNSWebhook.\\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+                              "SubscribeURL": "https://sns.eu-central-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:eu-central-1:613365526843:SNSWebhook&Token=2336412f37fb687f5d51e6e2425c464de12884d217e7e1b25b4c24b4450f9aa05e48016238eefabedec9af616cb7ef5ce99b4971b74f7070b6375e42a1052f57240475072de0c1898fdf2871f4d5dadcecd5ac9f846e33de54818faf18d05560073594e7694509eb33acb0b6f806918b",
+                              "Timestamp": "2023-04-26T15:04:47.883Z",
+                              "SignatureVersion": "1",
+                              "Signature": "u+0i/F/+qewEydLglZmwDwPBx7Kp1NuNfYwd8oLY7Wl0VJv5jGTC7BaJug019Rjebbkl2ykPcC2dEcgesjuPrTdPMBjiYqzpFWmToIdF32RhJCLZMZvaJsRHeIMqO4gRQVV3LRHo7eyiYzZ+hzkPldyl21buAgIjKUfv7Uz84nwNq7kG66m7TnuotqjYTp5zgvOYk++9Tk7K8PJeRXdnr+CMrL9ldctTK7gEoModQsCOXkvKQXfsAfy3bg0GC4G/Fk5hQyhLPy/SvBFjc+txHEr2AcYhoVQoxtiIKs2cRQiTpAVg6ImU0vC6uIQqftqjwo7kdth+Vl9itHufU3PSzw==",
+                              "SigningCertURL": "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem"
+                            }
+                    """;
+  private static final String NOTIFICATION_REQUEST =
+      """
+                            {
+                              "Type" : "Notification",
+                              "MessageId" : "2e062e6b-a527-5e68-b69b-72a8e42add60",
+                              "TopicArn" : "arn:aws:sns:eu-central-1:111222333444:SNSWebhook",
+                              "Subject" : "Subject - test",
+                              "Message" : "Hello, world",
+                              "Timestamp" : "2023-04-26T15:10:05.479Z",
+                              "SignatureVersion" : "1",
+                              "Signature" : "a2wKUBFEsuTer/0lL6SP7UPxCNKN23p1g/6xfhvPKsYcY+1a3DFDtlpe9hPOQvz7Mcwws82jO1+UvT0UzWP6Sl4Xo0Soh6okAzItfUj2Etq4i8zmT0eQdgKZw7/EIn7RGTciIgc3vd2JkWqwZvO2WFMl0g8Cxxz5/gXzEEdopRPEI3/cOXLvRo4uRQv3txm3wNeG+Gx9mCAxNlBKL/DcjVu/AtskRgtLyaAvZBguGXbh8iaai2+q6iQp4NrsB/tb/9Hn7iBwjN/cTrcD1GQDtI29IwPeEOJbQpdcb5geoO3w3IYpIhDTC2MlzTUu4ERPIgngZ6I5EvM9JIM3nS1fjA==",
+                              "SigningCertURL" : "https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem",
+                              "UnsubscribeURL" : "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:613365526843:SNSWebhook:4aa14ec3-a492-4a8e-8247-ea658d1aad96",
+                              "MessageAttributes" : {
+                                "attrName1" : {"Type":"String","Value":"attrVal"}
+                              }
+                            }
+                    """;
+
+  @BeforeEach
+  void beforeEach() throws Exception {
+    when(snsClientSupplier.messageManager(anyString())).thenReturn(messageManager);
+    testObject = new SnsWebhookExecutable(mapper, snsClientSupplier);
+  }
+
+  @Test
+  void triggerWebhook_SubscriptionAnyTopicAllowed_HappyCase() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "any");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "SubscriptionConfirmation");
+    final var confirmation = mock(SnsSubscriptionConfirmation.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody())
+        .thenReturn(SUBSCRIPTION_CONFIRMATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(confirmation);
+
+    // when
+    testObject.activate(ctx);
+    final var result = testObject.triggerWebhook(payload);
+
+    // then
+    verify(confirmation).confirmSubscription();
+    Assertions.assertThat(result.connectorData()).containsEntry("snsEventType", "Subscription");
+  }
+
+  @Test
+  void triggerWebhook_SubscriptionAllowlistSingleTopic_HappyCase() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "specific");
+    actualBPMNProperties.put(
+        "inbound.topicsAllowList", "arn:aws:sns:eu-central-1:111222333444:SNSWebhook");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "SubscriptionConfirmation");
+    final var confirmation = mock(SnsSubscriptionConfirmation.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody())
+        .thenReturn(SUBSCRIPTION_CONFIRMATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(confirmation);
+
+    // when
+    testObject.activate(ctx);
+    final var result = testObject.triggerWebhook(payload);
+
+    // then
+    verify(confirmation).confirmSubscription();
+    Assertions.assertThat(result.connectorData()).containsEntry("snsEventType", "Subscription");
+  }
+
+  @Test
+  void triggerWebhook_SubscriptionAllowlistMultipleTopics_HappyCase() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "specific");
+    actualBPMNProperties.put(
+        "inbound.topicsAllowList",
+        "arn:aws:sns:eu-central-1:111222333444:SNSWebhook, arn:aws:sns:eu-central-1:111222333444:AnotherTopic");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "SubscriptionConfirmation");
+    final var confirmation = mock(SnsSubscriptionConfirmation.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody())
+        .thenReturn(SUBSCRIPTION_CONFIRMATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(confirmation);
+
+    // when
+    testObject.activate(ctx);
+    final var result = testObject.triggerWebhook(payload);
+
+    // then
+    verify(confirmation).confirmSubscription();
+    Assertions.assertThat(result.connectorData()).containsEntry("snsEventType", "Subscription");
+  }
+
+  @Test
+  void triggerWebhook_SubscriptionNoAllowlistTopic_RaiseException() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "specific");
+    actualBPMNProperties.put(
+        "inbound.topicsAllowList", "arn:aws:sns:eu-central-1:111222333444:WrongTopic");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "SubscriptionConfirmation");
+    final var confirmation = mock(SnsSubscriptionConfirmation.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody())
+        .thenReturn(SUBSCRIPTION_CONFIRMATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(confirmation);
+
+    // when & then
+    testObject.activate(ctx);
+    Assert.assertThrows(Exception.class, () -> testObject.triggerWebhook(payload));
+  }
+
+  @Test
+  void triggerWebhook_SubscriptionAllowListEmpty_RaiseException() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "specific");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "SubscriptionConfirmation");
+    final var confirmation = mock(SnsSubscriptionConfirmation.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody())
+        .thenReturn(SUBSCRIPTION_CONFIRMATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(confirmation);
+
+    // when & then
+    testObject.activate(ctx);
+    Assert.assertThrows(Exception.class, () -> testObject.triggerWebhook(payload));
+  }
+
+  @Test
+  void triggerWebhook_Notification_HappyCase() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "any");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "Notification");
+    final var notification = mock(SnsNotification.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody()).thenReturn(NOTIFICATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(notification);
+
+    // when
+    testObject.activate(ctx);
+    final var result = testObject.triggerWebhook(payload);
+
+    // then
+    Assertions.assertThat(result.connectorData()).containsEntry("snsEventType", "Notification");
+  }
+
+  @Test
+  void triggerWebhook_UnknownMessage_ThrowsException() throws Exception {
+    // Configure connector
+    Map<String, String> actualBPMNProperties = new HashMap<>();
+    actualBPMNProperties.put("inbound.context", "snstest");
+    actualBPMNProperties.put("inbound.securitySubscriptionAllowedFor", "any");
+    when(props.getProperties()).thenReturn(actualBPMNProperties);
+    when(ctx.getProperties()).thenReturn(props);
+
+    // Configure payload
+    final var headers = new HashMap<>(snsRequestHeaders);
+    headers.put("x-amz-sns-message-type", "CorruptedNotification");
+    final var unknownMessage = mock(SnsUnknownMessage.class);
+    final var payload = mock(WebhookProcessingPayload.class);
+    when(payload.method()).thenReturn("GET");
+    when(payload.headers()).thenReturn(headers);
+    when(payload.rawBody()).thenReturn(NOTIFICATION_REQUEST.getBytes(StandardCharsets.UTF_8));
+
+    when(messageManager.parseMessage(any())).thenReturn(unknownMessage);
+
+    // when & then
+    testObject.activate(ctx);
+    Assert.assertThrows(Exception.class, () -> testObject.triggerWebhook(payload));
+  }
+}

--- a/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
+++ b/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/BaseTest.java
@@ -4,10 +4,10 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector;
+package io.camunda.connector.sns.outbound;
 
 import com.google.gson.Gson;
-import io.camunda.connector.suppliers.SnsGsonComponentSupplier;
+import io.camunda.connector.sns.suppliers.SnsGsonComponentSupplier;
 
 public abstract class BaseTest {
 

--- a/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionParametrizedTest.java
+++ b/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionParametrizedTest.java
@@ -4,18 +4,18 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector;
+package io.camunda.connector.sns.outbound;
 
-import static io.camunda.connector.BaseTest.ACTUAL_ACCESS_KEY;
-import static io.camunda.connector.BaseTest.ACTUAL_SECRET_KEY;
-import static io.camunda.connector.BaseTest.ACTUAL_TOPIC_ARN;
-import static io.camunda.connector.BaseTest.ACTUAL_TOPIC_REGION;
-import static io.camunda.connector.BaseTest.AWS_ACCESS_KEY;
-import static io.camunda.connector.BaseTest.AWS_SECRET_KEY;
-import static io.camunda.connector.BaseTest.AWS_TOPIC_ARN;
-import static io.camunda.connector.BaseTest.AWS_TOPIC_REGION;
-import static io.camunda.connector.BaseTest.GSON;
-import static io.camunda.connector.BaseTest.MSG_ID;
+import static io.camunda.connector.sns.outbound.BaseTest.ACTUAL_ACCESS_KEY;
+import static io.camunda.connector.sns.outbound.BaseTest.ACTUAL_SECRET_KEY;
+import static io.camunda.connector.sns.outbound.BaseTest.ACTUAL_TOPIC_ARN;
+import static io.camunda.connector.sns.outbound.BaseTest.ACTUAL_TOPIC_REGION;
+import static io.camunda.connector.sns.outbound.BaseTest.AWS_ACCESS_KEY;
+import static io.camunda.connector.sns.outbound.BaseTest.AWS_SECRET_KEY;
+import static io.camunda.connector.sns.outbound.BaseTest.AWS_TOPIC_ARN;
+import static io.camunda.connector.sns.outbound.BaseTest.AWS_TOPIC_REGION;
+import static io.camunda.connector.sns.outbound.BaseTest.GSON;
+import static io.camunda.connector.sns.outbound.BaseTest.MSG_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,10 +27,10 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.model.SnsConnectorRequest;
-import io.camunda.connector.model.SnsConnectorResult;
-import io.camunda.connector.suppliers.SnsClientSupplier;
-import io.camunda.connector.suppliers.SnsGsonComponentSupplier;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
+import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
+import io.camunda.connector.sns.suppliers.SnsGsonComponentSupplier;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import java.io.File;
 import java.io.IOException;

--- a/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
+++ b/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorFunctionTest.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector;
+package io.camunda.connector.sns.outbound;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -13,8 +13,8 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
-import io.camunda.connector.model.SnsConnectorResult;
-import io.camunda.connector.suppliers.SnsClientSupplier;
+import io.camunda.connector.sns.outbound.model.SnsConnectorResult;
+import io.camunda.connector.sns.suppliers.SnsClientSupplier;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorRequestTest.java
+++ b/connectors/sns/src/test/java/io/camunda/connector/sns/outbound/SnsConnectorRequestTest.java
@@ -4,7 +4,7 @@
  * See the License.txt file for more information. You may not use this file
  * except in compliance with the proprietary license.
  */
-package io.camunda.connector;
+package io.camunda.connector.sns.outbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.impl.ConnectorInputException;
-import io.camunda.connector.model.SnsConnectorRequest;
-import io.camunda.connector.model.SnsMessageAttribute;
+import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
+import io.camunda.connector.sns.outbound.model.SnsMessageAttribute;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Implements SNS inbound connector.

Closes #574 

## Context

The webhook functionality has been refactored via [PR](https://github.com/camunda/connectors-bundle/pull/603).

Leaving message below for historical purposes.

This is a 'typical' implementation of a custom webhook that has to be refactored. This PR is for demonstration purposes for the upcoming design review meeting.

Data and template: https://github.com/camunda/connectors-bundle/pull/573

![image](https://github.com/camunda/connectors-bundle/assets/108870003/8c4f1fee-b286-4090-862e-6de5065b9571)

Diagram source:

```
@startuml
'https://plantuml.com/sequence-diagram

'autonumber

actor user
participant runtime
participant connector

== Init runtime ==

runtime -> runtime: start

== Init connector ==

connector -> connector: init
connector -> runtime: <SPI> register path

== Webhook flow ==

user -> runtime: <REST> trigger webhook
runtime -> runtime: <??> check activation condition
runtime -> runtime: find webhook registration
runtime -> connector: activate (pass request to connector)
connector -> connector: process and validate
connector --> runtime: response
runtime -> runtime: <??> extract variables, start process, etc
runtime --> user: response

== Notes ==

note over runtime, connector
1. In two-step flows (I. confirm, II. notify), process will be started
2. Many webhooks will need to share common code, e.g. HMAC verification
3. <Ref ??> Activation condition and extract variables may or may not
belong to runtime - to be discussed
4. Flow specific to webhook-like systems (e.g., only WH has context path)
5. Webhook registration may or may not be a part of SDK; has to bea part
of SPI
end note

@enduml
```
