### PR TITLE
fix(config): remove default properties in the starter

### DIFF
--- a/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
+++ b/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
@@ -7,6 +7,9 @@
 #camunda.connector.polling.enabled=false
 #camunda.connector.webhook.enabled=false
 
+# Use this to configure the Operate polling interval for inbound connectors
+#camunda.connector.polling.interval=5000
+
 # Local demo installation with simple authentication, not meant for production use
 #zeebe.client.broker.gateway-address=127.0.0.1:26500
 #zeebe.client.security.plaintext=true

--- a/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
+++ b/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
@@ -1,10 +1,4 @@
 #server.port=9898
-camunda.connector.polling.enabled=true
-camunda.connector.polling.interval=5000
-
-spring.main.web-application-type=none
-
-operate.client.enabled=true
 
 # Local demo installation with simple authentication, not meant for production use
 #zeebe.client.broker.gateway-address=127.0.0.1:26500

--- a/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
+++ b/spring-boot-starter-camunda-connectors/src/main/resources/application.properties
@@ -1,5 +1,12 @@
 #server.port=9898
 
+# Use this property to enable Operate client (required for inbound connectors)
+#operate.client.enabled=true
+
+# Use these properties to disable inbound connectors (then Operate client won't be required)
+#camunda.connector.polling.enabled=false
+#camunda.connector.webhook.enabled=false
+
 # Local demo installation with simple authentication, not meant for production use
 #zeebe.client.broker.gateway-address=127.0.0.1:26500
 #zeebe.client.security.plaintext=true


### PR DESCRIPTION
## Description

If you use the starter in your project and define a custom YAML config, these default properties will override your custom config.

See discussion https://github.com/camunda-community-hub/spring-zeebe/issues/429#issuecomment-1549336734

