### PR TITLE
feat(runtime): add element id to inbound connector properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda.connector</groupId>
     <artifactId>connector-parent</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
 

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
@@ -128,7 +128,8 @@ public class ProcessDefinitionInspector {
                       HashMap::putAll),
               definition.getBpmnProcessId(),
               definition.getVersion().intValue(),
-              definition.getKey());
+              definition.getKey(),
+              element.getId());
 
       discoveredConnectors.add(properties);
     }

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/ActiveInboundConnectorResponse.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/ActiveInboundConnectorResponse.java
@@ -20,20 +20,30 @@ import java.util.Map;
 import java.util.Objects;
 
 public class ActiveInboundConnectorResponse {
+
   private final String bpmnProcessId;
+  private final String elementId;
   private final String type;
   private final Map<String, Object> data;
 
   public ActiveInboundConnectorResponse(
-      final String bpmnProcessId, final String type, final Map<String, Object> data) {
+      final String bpmnProcessId,
+      final String elementId,
+      final String type,
+      final Map<String, Object> data) {
 
     this.bpmnProcessId = bpmnProcessId;
+    this.elementId = elementId;
     this.type = type;
     this.data = data;
   }
 
   public String getBpmnProcessId() {
     return bpmnProcessId;
+  }
+
+  public String getElementId() {
+    return elementId;
   }
 
   public String getType() {
@@ -55,12 +65,13 @@ public class ActiveInboundConnectorResponse {
     ActiveInboundConnectorResponse that = (ActiveInboundConnectorResponse) o;
     return Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(type, that.type)
-        && Objects.equals(data, that.data);
+        && Objects.equals(data, that.data)
+        && Objects.equals(elementId, that.elementId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bpmnProcessId, type, data);
+    return Objects.hash(bpmnProcessId, elementId, type, data);
   }
 
   @Override
@@ -74,6 +85,8 @@ public class ActiveInboundConnectorResponse {
         + '\''
         + ", data="
         + data
+        + ", elementId='"
+        + elementId
         + '}';
   }
 }

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
@@ -41,21 +41,24 @@ public class InboundConnectorRestController {
 
   @GetMapping("/inbound")
   public List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
+      @RequestParam(required = false) String bpmnProcessId,
       @RequestParam(required = false) String type,
-      @RequestParam(required = false) String bpmnProcessId) {
+      @RequestParam(required = false) String elementId) {
 
     var activeConnectors = inboundManager.getActiveConnectorsByBpmnId();
     var filteredByBpmnProcessId = filterByBpmnProcessId(activeConnectors, bpmnProcessId);
     var filteredByType = filterByConnectorType(filteredByBpmnProcessId, type);
+    var filteredByElementId = filterByElementId(filteredByType, elementId);
 
     // TODO: replace this with a general solution
     // e.g. consider an optional method in InboundConnectorExecutable that returns data to be shown
     // in Modeler
-    return filteredByType.stream()
+    return filteredByElementId.stream()
         .map(
             properties ->
                 new ActiveInboundConnectorResponse(
                     properties.getBpmnProcessId(),
+                    properties.getElementId(),
                     properties.getType(),
                     extractPublicConnectorData(properties)))
         .collect(Collectors.toList());
@@ -80,6 +83,17 @@ public class InboundConnectorRestController {
     }
     return properties.stream()
         .filter(props -> type.equals(props.getType()))
+        .collect(Collectors.toList());
+  }
+
+  private List<InboundConnectorProperties> filterByElementId(
+      List<InboundConnectorProperties> properties, String elementId) {
+
+    if (elementId == null) {
+      return properties;
+    }
+    return properties.stream()
+        .filter(props -> elementId.equals(props.getElementId()))
         .collect(Collectors.toList());
   }
 

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -194,6 +194,7 @@ public class WebhookControllerPlainJavaTests {
             "inbound.variableMapping", "={}"),
         bpmnProcessId,
         version,
-        processDefinitionKey);
+        processDefinitionKey,
+        "testElement");
   }
 }

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
@@ -207,6 +207,7 @@ public class InboundConnectorManagerTest {
         Map.of(Constants.INBOUND_TYPE_KEYWORD, connectorConfig.getType()),
         procDef.getBpmnProcessId(),
         procDef.getVersion().intValue(),
-        procDef.getKey());
+        procDef.getKey(),
+        "test-element");
   }
 }

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -77,7 +77,8 @@ class InboundWebhookRestControllerTest {
                 "inbound.shouldValidateHmac", HMACSwitchCustomerChoice.disabled.name()),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
     InboundConnectorContext connectorContext =
         spy(
             new InboundConnectorContextBuilder()
@@ -122,7 +123,8 @@ class InboundWebhookRestControllerTest {
                 HMACSwitchCustomerChoice.disabled.name()),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
     InboundConnectorContext connectorContext =
         spy(
             new InboundConnectorContextBuilder()
@@ -177,7 +179,8 @@ class InboundWebhookRestControllerTest {
                 "inbound.hmacAlgorithm", "sha_256"),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
     InboundConnectorContext connectorContext =
         spy(
             new InboundConnectorContextBuilder()
@@ -221,7 +224,8 @@ class InboundWebhookRestControllerTest {
                 HMACSwitchCustomerChoice.disabled.name()),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
     InboundConnectorContext connectorContext =
         spy(
             new InboundConnectorContextBuilder()
@@ -267,7 +271,8 @@ class InboundWebhookRestControllerTest {
                 HMACSwitchCustomerChoice.disabled.name()),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
     InboundConnectorContext connectorContext =
         spy(
             new InboundConnectorContextBuilder()
@@ -313,7 +318,8 @@ class InboundWebhookRestControllerTest {
                 HMACSwitchCustomerChoice.disabled.name()),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
 
     InboundConnectorContext connectorContext =
         spy(
@@ -355,7 +361,8 @@ class InboundWebhookRestControllerTest {
                 "inbound.hmacAlgorithm", "sha_256"),
             "proc-id",
             2,
-            1);
+            1,
+            "elementId");
 
     InboundConnectorContext connectorContext =
         spy(


### PR DESCRIPTION
## Description

Adds `elementId` to the API endpoint to enable filtering in the web modeler.

⚠️ Depends on https://github.com/camunda/connector-sdk/pull/466

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/connectors-bundle/issues/591

