### PR TITLE
fix: adjust connection timeout regex

### DIFF
--- a/connectors/automation-anywhere/element-templates/automation-anywhere-connector.json
+++ b/connectors/automation-anywhere/element-templates/automation-anywhere-connector.json
@@ -511,11 +511,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/blue-prism/element-templates/blue-prism-connector.json
+++ b/connectors/blue-prism/element-templates/blue-prism-connector.json
@@ -427,11 +427,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/model/CommonRequest.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/model/CommonRequest.java
@@ -35,7 +35,7 @@ public class CommonRequest {
 
   @Valid @Secret private Authentication authentication;
 
-  @Pattern(regexp = "^([0-9]*$)|(secrets.*$)")
+  @Pattern(regexp = "^([0-9]+|secrets\\..+)$")
   @Secret
   private String connectionTimeoutInSeconds;
 

--- a/connectors/easy-post/element-templates/easy-post-connector.json
+++ b/connectors/easy-post/element-templates/easy-post-connector.json
@@ -788,11 +788,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/github/element-templates/github-outbound.json
+++ b/connectors/github/element-templates/github-outbound.json
@@ -1549,11 +1549,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
+++ b/connectors/google-maps-platform/element-templates/google-maps-platform-connector.json
@@ -436,7 +436,7 @@
         "notEmpty": false,
         "pattern": {
           "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/graphql/element-templates/graphql-connector.json
+++ b/connectors/graphql/element-templates/graphql-connector.json
@@ -331,12 +331,13 @@
         "type": "zeebe:input",
         "name": "graphql.connectionTimeoutInSeconds"
       },
+      "feel": "optional",
       "optional": true,
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/graphql/src/test/resources/requests/fail-cases-connection-timeout-validation.json
+++ b/connectors/graphql/src/test/resources/requests/fail-cases-connection-timeout-validation.json
@@ -99,5 +99,27 @@
         "token": "secrets.TOKEN_KEY"
       }
     }
+  },
+  {
+    "descriptionOfTest": "Value with 'secrets.' token in the middle",
+    "graphql": {
+      "method": "get",
+      "url": "https://camunda.io/http-endpoint",
+      "connectionTimeoutInSeconds": "bad secrets.TOKEN_KEY value"
+    },
+    "authentication": {
+      "type": "noAuth"
+    }
+  },
+  {
+    "descriptionOfTest": "Value with a numeric token in the middle",
+    "graphql": {
+      "method": "get",
+      "url": "https://camunda.io/http-endpoint",
+      "connectionTimeoutInSeconds": "bad 123 value"
+    },
+    "authentication": {
+      "type": "noAuth"
+    }
   }
 ]

--- a/connectors/http-json/element-templates/http-json-connector.json
+++ b/connectors/http-json/element-templates/http-json-connector.json
@@ -329,11 +329,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/http-json/src/test/resources/requests/fail-cases-connection-timeout-validation.json
+++ b/connectors/http-json/src/test/resources/requests/fail-cases-connection-timeout-validation.json
@@ -81,5 +81,23 @@
       "type": "bearer",
       "token": "secrets.TOKEN_KEY"
     }
+  },
+  {
+    "descriptionOfTest": "Value with 'secrets.' token in the middle",
+    "method": "get",
+    "url": "https://camunda.io/http-endpoint",
+    "connectionTimeoutInSeconds": "bad secrets.TOKEN_KEY value",
+    "authentication": {
+      "type": "noAuth"
+    }
+  },
+  {
+    "descriptionOfTest": "Value with a numeric token in the middle",
+    "method": "get",
+    "url": "https://camunda.io/http-endpoint",
+    "connectionTimeoutInSeconds": "bad 123 value",
+    "authentication": {
+      "type": "noAuth"
+    }
   }
 ]

--- a/connectors/openai/element-templates/openai-connector.json
+++ b/connectors/openai/element-templates/openai-connector.json
@@ -333,11 +333,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 30 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/operate/element-templates/operate-connector.json
+++ b/connectors/operate/element-templates/operate-connector.json
@@ -484,11 +484,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/power-automate/element-templates/power-automate-connector.json
+++ b/connectors/power-automate/element-templates/power-automate-connector.json
@@ -543,11 +543,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/twilio/element-templates/twilio-connector.json
+++ b/connectors/twilio/element-templates/twilio-connector.json
@@ -525,11 +525,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },

--- a/connectors/uipath/element-templates/uipath-connector.json
+++ b/connectors/uipath/element-templates/uipath-connector.json
@@ -519,11 +519,12 @@
         "name": "connectionTimeoutInSeconds"
       },
       "optional": true,
+      "feel": "optional",
       "constraints": {
         "notEmpty": false,
         "pattern": {
-          "value": "^([0-9]*$)|(secrets.*$)",
-          "message": "Must be timeout in seconds (default value is 20 seconds)"
+          "value": "^(=.+|[0-9]+|secrets\\..+)$",
+          "message": "Must be a timeout in seconds (default value is 20 seconds) or a FEEL expression"
         }
       }
     },


### PR DESCRIPTION
## Description

This PR:
- improves the regex used to validate connection timeout, both in the template and in the Java code
- enables optional FEEL for the connection timeout property

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #587 

