### PR TITLE
feat: support multiple secret providers

### DIFF
--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/ConnectorsAutoConfiguration.java
@@ -19,9 +19,12 @@ package io.camunda.connector.runtime;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.impl.config.ConnectorPropertyResolver;
 import io.camunda.connector.runtime.env.SpringConnectorPropertyResolver;
-import io.camunda.connector.runtime.env.SpringSecretProvider;
 import io.camunda.connector.runtime.inbound.InboundConnectorRuntimeConfiguration;
 import io.camunda.connector.runtime.outbound.OutboundConnectorRuntimeConfiguration;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -34,10 +37,20 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Import({OutboundConnectorRuntimeConfiguration.class, InboundConnectorRuntimeConfiguration.class})
 public class ConnectorsAutoConfiguration {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorsAutoConfiguration.class);
+
   @Bean
   @ConditionalOnMissingBean
-  public SecretProvider springSecretProvider(Environment environment) {
-    return new SpringSecretProvider(environment);
+  public SecretProviderAggregator springSecretProviderAggregator(
+      List<SecretProvider> secretProviders) {
+    if (secretProviders == null || secretProviders.isEmpty()) {
+      LOG.debug(
+          "No secret providers discovered as Spring beans. "
+              + "Falling back to SPI discovery and environment variables.");
+      return new SecretProviderAggregator();
+    }
+    LOG.debug("Using secret providers discovered as Spring beans: {}", secretProviders);
+    return new SecretProviderAggregator(secretProviders);
   }
 
   @Bean

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
@@ -16,11 +16,11 @@
  */
 package io.camunda.connector.runtime.inbound.lifecycle;
 
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.connector.runtime.util.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.util.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -40,8 +40,8 @@ public class InboundConnectorLifecycleConfiguration {
       InboundConnectorFactory connectorFactory,
       InboundCorrelationHandler correlationHandler,
       ProcessDefinitionInspector processDefinitionInspector,
-      SecretProvider secretProvider) {
+      SecretProviderAggregator secretProviderAggregator) {
     return new InboundConnectorManager(
-        connectorFactory, correlationHandler, processDefinitionInspector, secretProvider);
+        connectorFactory, correlationHandler, processDefinitionInspector, secretProviderAggregator);
   }
 }

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -17,12 +17,12 @@
 package io.camunda.connector.runtime.inbound.lifecycle;
 
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.impl.inbound.InboundConnectorProperties;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.util.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.util.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.util.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import io.camunda.operate.dto.ProcessDefinition;
 import java.util.*;
 import java.util.function.Consumer;
@@ -36,7 +36,7 @@ public class InboundConnectorManager {
   private final InboundConnectorFactory connectorFactory;
   private final InboundCorrelationHandler correlationHandler;
   private final ProcessDefinitionInspector processDefinitionInspector;
-  private final SecretProvider secretProvider;
+  private final SecretProviderAggregator secretProviderAggregator;
 
   // TODO: consider using external storage instead of these collections to allow multi-instance
   // setup
@@ -48,11 +48,11 @@ public class InboundConnectorManager {
       InboundConnectorFactory connectorFactory,
       InboundCorrelationHandler correlationHandler,
       ProcessDefinitionInspector processDefinitionInspector,
-      SecretProvider secretProvider) {
+      SecretProviderAggregator secretProviderAggregator) {
     this.connectorFactory = connectorFactory;
     this.correlationHandler = correlationHandler;
     this.processDefinitionInspector = processDefinitionInspector;
-    this.secretProvider = secretProvider;
+    this.secretProviderAggregator = secretProviderAggregator;
   }
 
   /** Process a batch of process definitions */
@@ -108,7 +108,7 @@ public class InboundConnectorManager {
 
     var inboundContext =
         new InboundConnectorContextImpl(
-            secretProvider, newProperties, correlationHandler, cancellationCallback);
+            secretProviderAggregator, newProperties, correlationHandler, cancellationCallback);
 
     var connector = new ActiveInboundConnector(executable, newProperties, inboundContext);
 

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/OutboundConnectorRuntimeConfiguration.java
@@ -16,11 +16,11 @@
  */
 package io.camunda.connector.runtime.outbound;
 
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorAnnotationProcessor;
 import io.camunda.connector.runtime.outbound.lifecycle.OutboundConnectorManager;
 import io.camunda.connector.runtime.util.outbound.DefaultOutboundConnectorFactory;
 import io.camunda.connector.runtime.util.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
@@ -46,13 +46,13 @@ public class OutboundConnectorRuntimeConfiguration {
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-      SecretProvider secretProvider,
+      SecretProviderAggregator secretProviderAggregator,
       MetricsRecorder metricsRecorder) {
     return new OutboundConnectorManager(
         jobWorkerManager,
         connectorFactory,
         commandExceptionHandlingStrategy,
-        secretProvider,
+        secretProviderAggregator,
         metricsRecorder);
   }
 

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -18,10 +18,10 @@ package io.camunda.connector.runtime.outbound.jobhandling;
 
 import io.camunda.connector.api.error.BpmnError;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler;
 import io.camunda.connector.runtime.util.outbound.ConnectorResult;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -43,10 +43,10 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   public SpringConnectorJobHandler(
       MetricsRecorder metricsRecorder,
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-      SecretProvider secretProvider,
+      SecretProviderAggregator secretProviderAggregator,
       OutboundConnectorFunction connectorFunction,
       OutboundConnectorConfiguration connectorConfiguration) {
-    super(connectorFunction, secretProvider);
+    super(connectorFunction, secretProviderAggregator);
     this.metricsRecorder = metricsRecorder;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.connectorConfiguration = connectorConfiguration;

--- a/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
+++ b/spring-boot-starter-camunda-connectors/src/main/java/io/camunda/connector/runtime/outbound/lifecycle/OutboundConnectorManager.java
@@ -17,10 +17,10 @@
 package io.camunda.connector.runtime.outbound.lifecycle;
 
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.outbound.jobhandling.SpringConnectorJobHandler;
 import io.camunda.connector.runtime.util.outbound.OutboundConnectorFactory;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
@@ -38,19 +38,19 @@ public class OutboundConnectorManager {
   private final JobWorkerManager jobWorkerManager;
   private final OutboundConnectorFactory connectorFactory;
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
-  private final SecretProvider secretProvider;
+  private final SecretProviderAggregator secretProviderAggregator;
   private final MetricsRecorder metricsRecorder;
 
   public OutboundConnectorManager(
       JobWorkerManager jobWorkerManager,
       OutboundConnectorFactory connectorFactory,
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-      SecretProvider secretProvider,
+      SecretProviderAggregator secretProviderAggregator,
       MetricsRecorder metricsRecorder) {
     this.jobWorkerManager = jobWorkerManager;
     this.connectorFactory = connectorFactory;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
-    this.secretProvider = secretProvider;
+    this.secretProviderAggregator = secretProviderAggregator;
     this.metricsRecorder = metricsRecorder;
   }
 
@@ -86,7 +86,7 @@ public class OutboundConnectorManager {
         new SpringConnectorJobHandler(
             metricsRecorder,
             commandExceptionHandlingStrategy,
-            secretProvider,
+            secretProviderAggregator,
             connectorFunction,
             connector);
 

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
-import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.impl.ConnectorUtil;
 import io.camunda.connector.impl.Constants;
 import io.camunda.connector.impl.inbound.InboundConnectorConfiguration;
@@ -42,6 +41,7 @@ import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.util.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.util.inbound.InboundConnectorFactory;
 import io.camunda.connector.runtime.util.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
 import io.camunda.operate.dto.ProcessDefinition;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +58,7 @@ public class InboundConnectorManagerTest {
   private ProcessDefinitionTestUtil procDefUtil;
   private InboundConnectorFactory factory;
   private InboundConnectorExecutable mockExecutable;
-  private SecretProvider secretProvider;
+  private SecretProviderAggregator secretProviderAggregator;
   private InboundCorrelationHandler correlationHandler;
 
   @BeforeEach
@@ -69,11 +69,13 @@ public class InboundConnectorManagerTest {
     factory = mock(InboundConnectorFactory.class);
     when(factory.getInstance(any())).thenReturn(mockExecutable);
 
-    secretProvider = mock(SecretProvider.class);
+    secretProviderAggregator = mock(SecretProviderAggregator.class);
 
     ProcessDefinitionInspector inspector = mock(ProcessDefinitionInspector.class);
 
-    manager = new InboundConnectorManager(factory, correlationHandler, inspector, secretProvider);
+    manager =
+        new InboundConnectorManager(
+            factory, correlationHandler, inspector, secretProviderAggregator);
     procDefUtil = new ProcessDefinitionTestUtil(manager, inspector);
   }
 
@@ -198,7 +200,7 @@ public class InboundConnectorManagerTest {
 
   private InboundConnectorContext inboundContext(InboundConnectorProperties properties) {
     return new InboundConnectorContextImpl(
-        secretProvider, properties, correlationHandler, (event) -> {});
+        secretProviderAggregator, properties, correlationHandler, (event) -> {});
   }
 
   private static final InboundConnectorConfiguration connectorConfig =

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/CustomSecretProviderAggregatorTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/CustomSecretProviderAggregatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret;
+
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.secret.CustomSecretProviderAggregatorTest.CustomSecretProviderAggregator;
+import io.camunda.connector.runtime.secret.providers.BarSpringSecretProvider;
+import io.camunda.connector.runtime.secret.providers.FooSpringSecretProvider;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Component;
+
+@SpringBootTest(
+    classes = {
+      TestConnectorRuntimeApplication.class,
+      FooSpringSecretProvider.class,
+      BarSpringSecretProvider.class,
+      CustomSecretProviderAggregator.class
+    })
+public class CustomSecretProviderAggregatorTest {
+
+  @Autowired SecretProviderAggregator secretProviderAggregator;
+
+  @Test
+  void customAggregatorCanOverrideDefault() {
+    // given 2 secret providers defined in the spring context
+    // and a custom secret provider aggregator
+    Assertions.assertThat(secretProviderAggregator.getSecret("FOO")).isEqualTo("CUSTOM");
+    Assertions.assertThat(secretProviderAggregator.getSecret("BAR")).isEqualTo("CUSTOM");
+  }
+
+  @Component
+  public static class CustomSecretProviderAggregator extends SecretProviderAggregator {
+
+    @Override
+    public String getSecret(String secretName) {
+      return "CUSTOM";
+    }
+  }
+}

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SPISecretProviderTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SPISecretProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret;
+
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {TestConnectorRuntimeApplication.class})
+public class SPISecretProviderTest {
+
+  @Autowired SecretProviderAggregator secretProviderAggregator;
+
+  @Test
+  void secretProviderIsLoadedFromServiceLoader() {
+    // given only the SPI secret provider is defined and no spring beans secret providers
+    // then it should be discovered
+    Assertions.assertThat(secretProviderAggregator.getSecret("SPI")).isEqualTo("SPI");
+  }
+}

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringSecretProviderTest.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/SpringSecretProviderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret;
+
+import io.camunda.connector.runtime.app.TestConnectorRuntimeApplication;
+import io.camunda.connector.runtime.secret.providers.BarSpringSecretProvider;
+import io.camunda.connector.runtime.secret.providers.FooSpringSecretProvider;
+import io.camunda.connector.runtime.util.secret.SecretProviderAggregator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {
+      TestConnectorRuntimeApplication.class,
+      FooSpringSecretProvider.class,
+      BarSpringSecretProvider.class
+    })
+public class SpringSecretProviderTest {
+
+  @Autowired SecretProviderAggregator secretProviderAggregator;
+
+  @Test
+  void secretProviderIsLoadedFromSpringContext() {
+    // given 2 secret providers defined in the spring context
+    // then the secret provider aggregator should be able to find them
+    Assertions.assertThat(secretProviderAggregator.getSecret("FOO")).isEqualTo("FOO");
+    Assertions.assertThat(secretProviderAggregator.getSecret("BAR")).isEqualTo("BAR");
+    // and SPI secret provider should not be loaded
+    Assertions.assertThat(secretProviderAggregator.getSecret("SPI")).isNull();
+  }
+}

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/BarSpringSecretProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret.providers;
+
+import io.camunda.connector.api.secret.SecretProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BarSpringSecretProvider implements SecretProvider {
+
+  @Override
+  public String getSecret(String s) {
+    if ("BAR".equals(s)) {
+      return "BAR";
+    } else {
+      return null;
+    }
+  }
+}

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/FooSpringSecretProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.secret.providers;
+
+import io.camunda.connector.api.secret.SecretProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FooSpringSecretProvider implements SecretProvider {
+
+  @Override
+  public String getSecret(String s) {
+    if ("FOO".equals(s)) {
+      return "FOO";
+    } else {
+      return null;
+    }
+  }
+}

--- a/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
+++ b/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/secret/providers/SpiSecretProvider.java
@@ -14,25 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.runtime.env;
+package io.camunda.connector.runtime.secret.providers;
 
 import io.camunda.connector.api.secret.SecretProvider;
-import org.springframework.core.env.Environment;
 
-/**
- * USes Spring {@link Environment} to resolve secrets (will look into properties files as well as
- * system properties)
- */
-public class SpringSecretProvider implements SecretProvider {
-
-  private final Environment environment;
-
-  public SpringSecretProvider(Environment environment) {
-    this.environment = environment;
-  }
+// note this is not defined as a Spring bean
+public class SpiSecretProvider implements SecretProvider {
 
   @Override
   public String getSecret(String s) {
-    return environment.getProperty(s);
+    if ("SPI".equals(s)) {
+      return "SPI";
+    } else {
+      return null;
+    }
   }
 }

--- a/spring-boot-starter-camunda-connectors/src/test/resources/META-INF/services/io.camunda.connector.api.secret.SecretProvider
+++ b/spring-boot-starter-camunda-connectors/src/test/resources/META-INF/services/io.camunda.connector.api.secret.SecretProvider
@@ -1,0 +1,1 @@
+io.camunda.connector.runtime.secret.providers.SpiSecretProvider


### PR DESCRIPTION
## Description

This PR adds support for the new multiple secret providers features from the Connector SDK.
It is based on the following ideas:

- Secret Providers can be defined as Spring beans
- Secret Providers can also be defined using the ServiceLoader pattern
- Strategy to select the secret provider can be customized by implementing `SecretProviderAggregator`. It can also be defined as a Spring bean, overriding the default simple implementation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

see also: [previous PR in the SDK](https://github.com/camunda/connector-sdk/pull/472)

closes https://github.com/camunda/connector-sdk/issues/425

