### PR TITLE
feat: inbound metrics

### DIFF
--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -12,6 +12,5 @@ camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 camunda.connector.webhook.enabled=true
 
-management.server.port=9080
 management.context-path=/actuator
 management.endpoints.web.exposure.include=metrics,health,prometheus

--- a/bundle/default-bundle/src/main/resources/application.properties
+++ b/bundle/default-bundle/src/main/resources/application.properties
@@ -11,3 +11,7 @@ camunda.operate.client.url=http://localhost:8081
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 camunda.connector.webhook.enabled=true
+
+management.server.port=9080
+management.context-path=/actuator
+management.endpoints.web.exposure.include=metrics,health,prometheus

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -70,7 +70,7 @@ public class InboundCorrelationHandler {
             + " is not supported by Runtime");
   }
 
-  private InboundConnectorResult<ProcessInstance> triggerStartEvent(
+  protected InboundConnectorResult<ProcessInstance> triggerStartEvent(
       InboundConnectorProperties properties, Object variables) {
     StartEventCorrelationPoint correlationPoint =
         (StartEventCorrelationPoint) properties.getCorrelationPoint();
@@ -106,7 +106,7 @@ public class InboundCorrelationHandler {
     }
   }
 
-  private InboundConnectorResult<CorrelatedMessage> triggerMessage(
+  protected InboundConnectorResult<CorrelatedMessage> triggerMessage(
       InboundConnectorProperties properties, Object variables) {
 
     MessageCorrelationPoint correlationPoint =
@@ -142,7 +142,7 @@ public class InboundCorrelationHandler {
     }
   }
 
-  private boolean isActivationConditionMet(InboundConnectorProperties properties, Object context) {
+  protected boolean isActivationConditionMet(InboundConnectorProperties properties, Object context) {
 
     String activationCondition = properties.getProperty(ACTIVATION_CONDITION_KEYWORD);
     if (activationCondition == null || activationCondition.trim().length() == 0) {
@@ -157,7 +157,7 @@ public class InboundCorrelationHandler {
     }
   }
 
-  private String extractCorrelationKey(InboundConnectorProperties properties, Object context) {
+  protected String extractCorrelationKey(InboundConnectorProperties properties, Object context) {
     String correlationKeyExpression =
         properties.getRequiredProperty(CORRELATION_KEY_EXPRESSION_KEYWORD);
     try {
@@ -167,7 +167,7 @@ public class InboundCorrelationHandler {
     }
   }
 
-  private Object extractVariables(Object rawVariables, InboundConnectorProperties properties) {
+  protected Object extractVariables(Object rawVariables, InboundConnectorProperties properties) {
     if (properties.getProperty(LEGACY_VARIABLE_MAPPING_KEYWORD) != null) {
       // if legacy variable mapping is used, we don't need to extract variables
       // because they are already extracted by the webhook connector

--- a/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-core/src/main/java/io/camunda/connector/runtime/core/inbound/correlation/InboundCorrelationHandler.java
@@ -142,7 +142,8 @@ public class InboundCorrelationHandler {
     }
   }
 
-  protected boolean isActivationConditionMet(InboundConnectorProperties properties, Object context) {
+  protected boolean isActivationConditionMet(
+      InboundConnectorProperties properties, Object context) {
 
     String activationCondition = properties.getProperty(ACTIVATION_CONDITION_KEYWORD);
     if (activationCondition == null || activationCondition.trim().length() == 0) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -33,7 +33,8 @@ public class InboundConnectorRuntimeConfiguration {
 
   @Bean
   public InboundCorrelationHandler inboundCorrelationHandler(
-      final ZeebeClient zeebeClient, final FeelEngineWrapper feelEngine,
+      final ZeebeClient zeebeClient,
+      final FeelEngineWrapper feelEngine,
       final MetricsRecorder metricsRecorder) {
     return new MeteredInboundCorrelationHandler(zeebeClient, feelEngine, metricsRecorder);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/InboundConnectorRuntimeConfiguration.java
@@ -20,7 +20,9 @@ import io.camunda.connector.runtime.core.feel.FeelEngineWrapper;
 import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionImportConfiguration;
 import io.camunda.connector.runtime.inbound.lifecycle.InboundConnectorLifecycleConfiguration;
+import io.camunda.connector.runtime.inbound.lifecycle.MeteredInboundCorrelationHandler;
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,7 +33,8 @@ public class InboundConnectorRuntimeConfiguration {
 
   @Bean
   public InboundCorrelationHandler inboundCorrelationHandler(
-      final ZeebeClient zeebeClient, final FeelEngineWrapper feelEngine) {
-    return new InboundCorrelationHandler(zeebeClient, feelEngine);
+      final ZeebeClient zeebeClient, final FeelEngineWrapper feelEngine,
+      final MetricsRecorder metricsRecorder) {
+    return new MeteredInboundCorrelationHandler(zeebeClient, feelEngine, metricsRecorder);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
@@ -27,7 +27,8 @@ public class ProcessDefinitionImportConfiguration {
 
   @Bean
   public ProcessDefinitionImporter processDefinitionImporter(
-      CamundaOperateClient client, InboundConnectorManager manager,
+      CamundaOperateClient client,
+      InboundConnectorManager manager,
       MetricsRecorder metricsRecorder) {
     return new ProcessDefinitionImporter(client, manager, metricsRecorder);
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImportConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.connector.runtime.inbound.importer;
 
 import io.camunda.connector.runtime.inbound.lifecycle.InboundConnectorManager;
 import io.camunda.operate.CamundaOperateClient;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,8 +27,9 @@ public class ProcessDefinitionImportConfiguration {
 
   @Bean
   public ProcessDefinitionImporter processDefinitionImporter(
-      CamundaOperateClient client, InboundConnectorManager manager) {
-    return new ProcessDefinitionImporter(client, manager);
+      CamundaOperateClient client, InboundConnectorManager manager,
+      MetricsRecorder metricsRecorder) {
+    return new ProcessDefinitionImporter(client, manager, metricsRecorder);
   }
 
   @Bean

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -43,7 +43,8 @@ public class ProcessDefinitionImporter {
 
   @Autowired
   public ProcessDefinitionImporter(
-      CamundaOperateClient camundaOperateClient, InboundConnectorManager inboundManager,
+      CamundaOperateClient camundaOperateClient,
+      InboundConnectorManager inboundManager,
       @Autowired(required = false) MetricsRecorder metricsRecorder) {
     this.camundaOperateClient = camundaOperateClient;
     this.inboundManager = inboundManager;
@@ -87,8 +88,7 @@ public class ProcessDefinitionImporter {
   private void meter(int count) {
     if (metricsRecorder != null) {
       metricsRecorder.increase(
-          Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED,
-          null, null, count);
+          Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED, null, null, count);
     }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporter.java
@@ -17,11 +17,13 @@
 package io.camunda.connector.runtime.inbound.importer;
 
 import io.camunda.connector.runtime.inbound.lifecycle.InboundConnectorManager;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.dto.ProcessDefinition;
 import io.camunda.operate.dto.SearchResult;
 import io.camunda.operate.exception.OperateException;
 import io.camunda.operate.search.SearchQuery;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,14 +37,17 @@ public class ProcessDefinitionImporter {
 
   private final CamundaOperateClient camundaOperateClient;
   private final InboundConnectorManager inboundManager;
+  private final MetricsRecorder metricsRecorder;
 
   private List<Object> paginationIndex;
 
   @Autowired
   public ProcessDefinitionImporter(
-      CamundaOperateClient camundaOperateClient, InboundConnectorManager inboundManager) {
+      CamundaOperateClient camundaOperateClient, InboundConnectorManager inboundManager,
+      @Autowired(required = false) MetricsRecorder metricsRecorder) {
     this.camundaOperateClient = camundaOperateClient;
     this.inboundManager = inboundManager;
+    this.metricsRecorder = metricsRecorder;
   }
 
   @Scheduled(fixedDelayString = "${camunda.connector.polling.interval:5000}")
@@ -67,15 +72,23 @@ public class ProcessDefinitionImporter {
     } while (result.getItems().size() > 0);
   }
 
-  private void handleImportedDefinitions(List<ProcessDefinition> processDefinitions)
-      throws OperateException {
+  private void handleImportedDefinitions(List<ProcessDefinition> processDefinitions) {
 
-    if (processDefinitions == null) {
+    if (processDefinitions == null || processDefinitions.isEmpty()) {
       LOG.trace("... returned no process definitions.");
       return;
     }
     LOG.trace("... returned " + processDefinitions.size() + " process definitions.");
+    meter(processDefinitions.size());
 
     inboundManager.registerProcessDefinitions(processDefinitions);
+  }
+
+  private void meter(int count) {
+    if (metricsRecorder != null) {
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED,
+          null, null, count);
+    }
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorLifecycleConfiguration.java
@@ -22,6 +22,7 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,12 +43,14 @@ public class InboundConnectorLifecycleConfiguration {
       InboundCorrelationHandler correlationHandler,
       ProcessDefinitionInspector processDefinitionInspector,
       SecretProviderAggregator secretProviderAggregator,
+      MetricsRecorder metricsRecorder,
       @Autowired(required = false) WebhookConnectorRegistry webhookConnectorRegistry) {
     return new InboundConnectorManager(
         connectorFactory,
         correlationHandler,
         processDefinitionInspector,
         secretProviderAggregator,
+        metricsRecorder,
         webhookConnectorRegistry);
   }
 }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -79,9 +79,7 @@ public class InboundConnectorManager {
     this.webhookConnectorRegistry = webhookConnectorRegistry;
   }
 
-  /**
-   * Process a batch of process definitions
-   */
+  /** Process a batch of process definitions */
   public void registerProcessDefinitions(List<ProcessDefinition> processDefinitions) {
     if (processDefinitions == null || processDefinitions.isEmpty()) {
       return;
@@ -114,9 +112,7 @@ public class InboundConnectorManager {
     }
   }
 
-  /**
-   * Check whether process definition with provided key is already registered
-   */
+  /** Check whether process definition with provided key is already registered */
   protected boolean isProcessDefinitionRegistered(long processDefinitionKey) {
     return registeredProcessDefinitionKeys.contains(processDefinitionKey);
   }
@@ -155,9 +151,7 @@ public class InboundConnectorManager {
       }
       inboundContext.reportHealth(Health.up());
       metricsRecorder.increase(
-          Inbound.METRIC_NAME_ACTIVATIONS,
-          Inbound.ACTION_ACTIVATED,
-          newProperties.getType());
+          Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_ACTIVATED, newProperties.getType());
     } catch (Exception e) {
       inboundContext.reportHealth(Health.down(e));
       // log and continue with other connectors anyway
@@ -186,9 +180,7 @@ public class InboundConnectorManager {
   private void deactivateConnector(InboundConnectorProperties properties) {
     findActiveConnector(properties).ifPresent(this::deactivateConnector);
     metricsRecorder.increase(
-        Inbound.METRIC_NAME_ACTIVATIONS,
-        Inbound.ACTION_DEACTIVATED,
-        properties.getType());
+        Inbound.METRIC_NAME_ACTIVATIONS, Inbound.ACTION_DEACTIVATED, properties.getType());
   }
 
   private void deactivateConnector(ActiveInboundConnector connector) {

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -26,7 +26,9 @@ import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationH
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
 import io.camunda.operate.dto.ProcessDefinition;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class InboundConnectorManager {
+
   private static final Logger LOG = LoggerFactory.getLogger(InboundConnectorManager.class);
 
   public static final String WEBHOOK_CONTEXT_BPMN_FIELD = "inbound.context";
@@ -53,6 +56,7 @@ public class InboundConnectorManager {
   private final ProcessDefinitionInspector processDefinitionInspector;
   private final SecretProviderAggregator secretProviderAggregator;
   private final WebhookConnectorRegistry webhookConnectorRegistry;
+  private final MetricsRecorder metricsRecorder;
 
   // TODO: consider using external storage instead of these collections to allow multi-instance
   // setup
@@ -65,15 +69,19 @@ public class InboundConnectorManager {
       InboundCorrelationHandler correlationHandler,
       ProcessDefinitionInspector processDefinitionInspector,
       SecretProviderAggregator secretProviderAggregator,
+      MetricsRecorder metricsRecorder,
       @Autowired(required = false) WebhookConnectorRegistry webhookConnectorRegistry) {
     this.connectorFactory = connectorFactory;
     this.correlationHandler = correlationHandler;
     this.processDefinitionInspector = processDefinitionInspector;
     this.secretProviderAggregator = secretProviderAggregator;
+    this.metricsRecorder = metricsRecorder;
     this.webhookConnectorRegistry = webhookConnectorRegistry;
   }
 
-  /** Process a batch of process definitions */
+  /**
+   * Process a batch of process definitions
+   */
   public void registerProcessDefinitions(List<ProcessDefinition> processDefinitions) {
     if (processDefinitions == null || processDefinitions.isEmpty()) {
       return;
@@ -106,7 +114,9 @@ public class InboundConnectorManager {
     }
   }
 
-  /** Check whether process definition with provided key is already registered */
+  /**
+   * Check whether process definition with provided key is already registered
+   */
   protected boolean isProcessDefinitionRegistered(long processDefinitionKey) {
     return registeredProcessDefinitionKeys.contains(processDefinitionKey);
   }
@@ -144,10 +154,18 @@ public class InboundConnectorManager {
         LOG.trace("Registering webhook: " + newProperties.getType());
       }
       inboundContext.reportHealth(Health.up());
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_ACTIVATIONS,
+          Inbound.ACTION_ACTIVATED,
+          newProperties.getType());
     } catch (Exception e) {
       inboundContext.reportHealth(Health.down(e));
       // log and continue with other connectors anyway
       LOG.error("Failed to activate inbound connector " + newProperties, e);
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_ACTIVATIONS,
+          Inbound.ACTION_ACTIVATION_FAILED,
+          newProperties.getType());
     }
   }
 
@@ -167,6 +185,10 @@ public class InboundConnectorManager {
 
   private void deactivateConnector(InboundConnectorProperties properties) {
     findActiveConnector(properties).ifPresent(this::deactivateConnector);
+    metricsRecorder.increase(
+        Inbound.METRIC_NAME_ACTIVATIONS,
+        Inbound.ACTION_DEACTIVATED,
+        properties.getType());
   }
 
   private void deactivateConnector(ActiveInboundConnector connector) {
@@ -178,6 +200,10 @@ public class InboundConnectorManager {
         webhookConnectorRegistry.deregister(connector);
         LOG.trace("Unregistering webhook: " + connector.properties().getType());
       }
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_ACTIVATIONS,
+          Inbound.ACTION_DEACTIVATED,
+          connector.properties().getType());
     } catch (Exception e) {
       // log and continue with other connectors anyway
       LOG.error("Failed to deactivate inbound connector " + connector, e);

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/MeteredInboundCorrelationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.inbound.lifecycle;
 
 import io.camunda.connector.api.inbound.InboundConnectorResult;
@@ -12,15 +28,15 @@ public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler 
 
   private final MetricsRecorder metricsRecorder;
 
-  public MeteredInboundCorrelationHandler(ZeebeClient zeebeClient,
-      FeelEngineWrapper feelEngine, MetricsRecorder metricsRecorder) {
+  public MeteredInboundCorrelationHandler(
+      ZeebeClient zeebeClient, FeelEngineWrapper feelEngine, MetricsRecorder metricsRecorder) {
     super(zeebeClient, feelEngine);
     this.metricsRecorder = metricsRecorder;
   }
 
   @Override
-  protected boolean isActivationConditionMet(InboundConnectorProperties properties,
-      Object context) {
+  protected boolean isActivationConditionMet(
+      InboundConnectorProperties properties, Object context) {
     boolean isConditionMet = super.isActivationConditionMet(properties, context);
     if (!isConditionMet) {
       metricsRecorder.increase(
@@ -32,27 +48,21 @@ public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler 
   }
 
   @Override
-  public InboundConnectorResult<?> correlate(InboundConnectorProperties properties,
-      Object variables) {
+  public InboundConnectorResult<?> correlate(
+      InboundConnectorProperties properties, Object variables) {
     metricsRecorder.increase(
-        Inbound.METRIC_NAME_TRIGGERS,
-        Inbound.ACTION_TRIGGERED,
-        properties.getType());
+        Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_TRIGGERED, properties.getType());
 
     try {
       var result = super.correlate(properties, variables);
       if (result.isActivated()) {
         metricsRecorder.increase(
-            Inbound.METRIC_NAME_TRIGGERS,
-            Inbound.ACTION_CORRELATED,
-            properties.getType());
+            Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_CORRELATED, properties.getType());
       }
       return result;
     } catch (Exception e) {
       metricsRecorder.increase(
-          Inbound.METRIC_NAME_TRIGGERS,
-          Inbound.ACTION_CORRELATION_FAILED,
-          properties.getType());
+          Inbound.METRIC_NAME_TRIGGERS, Inbound.ACTION_CORRELATION_FAILED, properties.getType());
       throw e;
     }
   }

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/MeteredInboundCorrelationHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/MeteredInboundCorrelationHandler.java
@@ -1,0 +1,59 @@
+package io.camunda.connector.runtime.inbound.lifecycle;
+
+import io.camunda.connector.api.inbound.InboundConnectorResult;
+import io.camunda.connector.impl.inbound.InboundConnectorProperties;
+import io.camunda.connector.runtime.core.feel.FeelEngineWrapper;
+import io.camunda.connector.runtime.core.inbound.correlation.InboundCorrelationHandler;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics.Inbound;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+
+public class MeteredInboundCorrelationHandler extends InboundCorrelationHandler {
+
+  private final MetricsRecorder metricsRecorder;
+
+  public MeteredInboundCorrelationHandler(ZeebeClient zeebeClient,
+      FeelEngineWrapper feelEngine, MetricsRecorder metricsRecorder) {
+    super(zeebeClient, feelEngine);
+    this.metricsRecorder = metricsRecorder;
+  }
+
+  @Override
+  protected boolean isActivationConditionMet(InboundConnectorProperties properties,
+      Object context) {
+    boolean isConditionMet = super.isActivationConditionMet(properties, context);
+    if (!isConditionMet) {
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_TRIGGERS,
+          Inbound.ACTION_ACTIVATION_CONDITION_FAILED,
+          properties.getType());
+    }
+    return isConditionMet;
+  }
+
+  @Override
+  public InboundConnectorResult<?> correlate(InboundConnectorProperties properties,
+      Object variables) {
+    metricsRecorder.increase(
+        Inbound.METRIC_NAME_TRIGGERS,
+        Inbound.ACTION_TRIGGERED,
+        properties.getType());
+
+    try {
+      var result = super.correlate(properties, variables);
+      if (result.isActivated()) {
+        metricsRecorder.increase(
+            Inbound.METRIC_NAME_TRIGGERS,
+            Inbound.ACTION_CORRELATED,
+            properties.getType());
+      }
+      return result;
+    } catch (Exception e) {
+      metricsRecorder.increase(
+          Inbound.METRIC_NAME_TRIGGERS,
+          Inbound.ACTION_CORRELATION_FAILED,
+          properties.getType());
+      throw e;
+    }
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.connector.runtime.metrics;
 
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
@@ -19,7 +35,8 @@ public class ConnectorMetrics {
   public static class Inbound {
     public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
     public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
-    public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED = "camunda.connector.inbound.process-definitions-checked";
+    public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED =
+        "camunda.connector.inbound.process-definitions-checked";
 
     public static final String ACTION_ACTIVATED = "activated";
     public static final String ACTION_DEACTIVATED = "deactivated";

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/metrics/ConnectorMetrics.java
@@ -1,0 +1,33 @@
+package io.camunda.connector.runtime.metrics;
+
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+
+public class ConnectorMetrics {
+
+  public static class Outbound {
+
+    public static final String METRIC_NAME_INVOCATIONS = "camunda.connector.outbound.invocations";
+    public static final String METRIC_NAME_TIME = "camunda.connector.outbound.execution-time";
+
+    // same as job worker metrics from Spring Zeebe
+    public static final String ACTION_ACTIVATED = MetricsRecorder.ACTION_ACTIVATED;
+    public static final String ACTION_COMPLETED = MetricsRecorder.ACTION_COMPLETED;
+    public static final String ACTION_FAILED = MetricsRecorder.ACTION_FAILED;
+    public static final String ACTION_BPMN_ERROR = MetricsRecorder.ACTION_BPMN_ERROR;
+  }
+
+  public static class Inbound {
+    public static final String METRIC_NAME_ACTIVATIONS = "camunda.connector.inbound.activations";
+    public static final String METRIC_NAME_TRIGGERS = "camunda.connector.inbound.triggers";
+    public static final String METRIC_NAME_INBOUND_PROCESS_DEFINITIONS_CHECKED = "camunda.connector.inbound.process-definitions-checked";
+
+    public static final String ACTION_ACTIVATED = "activated";
+    public static final String ACTION_DEACTIVATED = "deactivated";
+    public static final String ACTION_ACTIVATION_FAILED = "activation-failed";
+
+    public static final String ACTION_TRIGGERED = "triggered";
+    public static final String ACTION_ACTIVATION_CONDITION_FAILED = "activation-condition-failed";
+    public static final String ACTION_CORRELATED = "correlated";
+    public static final String ACTION_CORRELATION_FAILED = "correlation-failed";
+  }
+}

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -22,6 +22,8 @@ import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration;
 import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler;
 import io.camunda.connector.runtime.core.outbound.ConnectorResult;
 import io.camunda.connector.runtime.core.secret.SecretProviderAggregator;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics;
+import io.camunda.connector.runtime.metrics.ConnectorMetrics.Outbound;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
@@ -55,11 +57,12 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   @Override
   public void handle(JobClient client, ActivatedJob job) {
     metricsRecorder.executeWithTimer(
+        ConnectorMetrics.Outbound.METRIC_NAME_TIME,
         job.getType(),
         () -> {
           metricsRecorder.increase(
-              MetricsRecorder.METRIC_NAME_OUTBOUND_CONNECTOR,
-              MetricsRecorder.ACTION_ACTIVATED,
+              Outbound.METRIC_NAME_INVOCATIONS,
+              Outbound.ACTION_ACTIVATED,
               connectorConfiguration.getType());
           super.handle(client, job);
         });
@@ -68,8 +71,8 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   @Override
   protected void failJob(JobClient client, ActivatedJob job, Exception exception) {
     metricsRecorder.increase(
-        MetricsRecorder.METRIC_NAME_OUTBOUND_CONNECTOR,
-        MetricsRecorder.ACTION_FAILED,
+        Outbound.METRIC_NAME_INVOCATIONS,
+        Outbound.ACTION_FAILED,
         connectorConfiguration.getType());
     // rethrowing the exception enables retries (handled by JobRunnableFactory)
     throw new RuntimeException(exception);
@@ -78,16 +81,16 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   @Override
   protected void throwBpmnError(JobClient client, ActivatedJob job, BpmnError value) {
     metricsRecorder.increase(
-        MetricsRecorder.METRIC_NAME_OUTBOUND_CONNECTOR,
-        MetricsRecorder.ACTION_BPMN_ERROR,
+        Outbound.METRIC_NAME_INVOCATIONS,
+        Outbound.ACTION_BPMN_ERROR,
         connectorConfiguration.getType());
     new CommandWrapper(
-            client
-                .newThrowErrorCommand(job.getKey())
-                .errorCode(value.getCode())
-                .errorMessage(value.getMessage()),
-            job,
-            commandExceptionHandlingStrategy)
+        client
+            .newThrowErrorCommand(job.getKey())
+            .errorCode(value.getCode())
+            .errorMessage(value.getMessage()),
+        job,
+        commandExceptionHandlingStrategy)
         .executeAsync();
   }
 
@@ -95,8 +98,8 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   @SuppressWarnings({"unchecked", "rawtypes"})
   protected void completeJob(JobClient client, ActivatedJob job, ConnectorResult result) {
     metricsRecorder.increase(
-        MetricsRecorder.METRIC_NAME_OUTBOUND_CONNECTOR,
-        MetricsRecorder.ACTION_COMPLETED,
+        Outbound.METRIC_NAME_INVOCATIONS,
+        Outbound.ACTION_COMPLETED,
         connectorConfiguration.getType());
     CompleteJobCommandStep1 commandStep = client.newCompleteCommand(job.getKey());
     FinalCommandStep finalCommandStep = commandStep.variables(result.getVariables());

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/outbound/jobhandling/SpringConnectorJobHandler.java
@@ -71,9 +71,7 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
   @Override
   protected void failJob(JobClient client, ActivatedJob job, Exception exception) {
     metricsRecorder.increase(
-        Outbound.METRIC_NAME_INVOCATIONS,
-        Outbound.ACTION_FAILED,
-        connectorConfiguration.getType());
+        Outbound.METRIC_NAME_INVOCATIONS, Outbound.ACTION_FAILED, connectorConfiguration.getType());
     // rethrowing the exception enables retries (handled by JobRunnableFactory)
     throw new RuntimeException(exception);
   }
@@ -85,12 +83,12 @@ public class SpringConnectorJobHandler extends ConnectorJobHandler {
         Outbound.ACTION_BPMN_ERROR,
         connectorConfiguration.getType());
     new CommandWrapper(
-        client
-            .newThrowErrorCommand(job.getKey())
-            .errorCode(value.getCode())
-            .errorMessage(value.getMessage()),
-        job,
-        commandExceptionHandlingStrategy)
+            client
+                .newThrowErrorCommand(job.getKey())
+                .errorCode(value.getCode())
+                .errorMessage(value.getMessage()),
+            job,
+            commandExceptionHandlingStrategy)
         .executeAsync();
   }
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionImporterTest.java
@@ -72,7 +72,7 @@ public class ProcessDefinitionImporterTest {
         .thenReturn(firstOperateResponse)
         .thenReturn(secondOperateResponse);
 
-    var importer = new ProcessDefinitionImporter(operate, manager);
+    var importer = new ProcessDefinitionImporter(operate, manager, null);
 
     // when
     importer.scheduleImport();

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManagerTest.java
@@ -47,6 +47,7 @@ import io.camunda.connector.runtime.inbound.ProcessDefinitionTestUtil;
 import io.camunda.connector.runtime.inbound.importer.ProcessDefinitionInspector;
 import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
 import io.camunda.operate.dto.ProcessDefinition;
+import io.camunda.zeebe.spring.client.metrics.DefaultNoopMetricsRecorder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class InboundConnectorManagerTest {
+
   private InboundConnectorManager manager;
   private ProcessDefinitionTestUtil procDefUtil;
   private InboundConnectorFactory factory;
@@ -79,7 +81,12 @@ public class InboundConnectorManagerTest {
 
     manager =
         new InboundConnectorManager(
-            factory, correlationHandler, inspector, secretProviderAggregator, webhookRegistry);
+            factory,
+            correlationHandler,
+            inspector,
+            secretProviderAggregator,
+            new DefaultNoopMetricsRecorder(),
+            webhookRegistry);
     procDefUtil = new ProcessDefinitionTestUtil(manager, inspector);
   }
 
@@ -244,7 +251,12 @@ public class InboundConnectorManagerTest {
     // emulating camunda.connector.webhook.enabled=false
     manager =
         new InboundConnectorManager(
-            factory, correlationHandler, inspector, secretProviderAggregator, null);
+            factory,
+            correlationHandler,
+            inspector,
+            secretProviderAggregator,
+            new DefaultNoopMetricsRecorder(),
+            null);
     procDefUtil = new ProcessDefinitionTestUtil(manager, inspector);
 
     when(factory.getInstance("io.camunda:test-webhook:1")).thenReturn(webhookConnectorExecutable);

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <inceptionYear>2022</inceptionYear>
 
   <properties>
-    <version.spring-zeebe>8.2.2</version.spring-zeebe>
+    <version.spring-zeebe>8.2.3-SNAPSHOT</version.spring-zeebe>
     <version.operate-client>8.1.8</version.operate-client>
 
     <version.spring-boot>3.1.0</version.spring-boot>


### PR DESCRIPTION
## Description

In this PR I added new metrics for inbound connectors and slightly refined the existing metrics.

- Count inbound activations, deactivations, triggers as well as trigger outcomes, plus imported process definitions.
- The semantics of inbound metrics were changes:
  - Previously `activated` metric related to connector trigger events.
  - Now it is related to connector instance activations/deactivations, and triggers are recorded separately.

⚠️ Depends on https://github.com/camunda-community-hub/spring-zeebe/pull/440

Grafana dashboard will follow in another PR.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/team-connectors/issues/290

