### PR TITLE
709 parse amqp headers as strings

### DIFF
--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/AMQPPropertyUtil.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/AMQPPropertyUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.rabbitmq.inbound;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.LongString;
+import io.camunda.connector.rabbitmq.inbound.model.RabbitMqMessageProperties;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AMQPPropertyUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(AMQPPropertyUtil.class);
+
+  public static RabbitMqMessageProperties toProperties(AMQP.BasicProperties properties) {
+    return new RabbitMqMessageProperties(
+        properties.getContentType(),
+        properties.getContentEncoding(),
+        parseHeaders(properties.getHeaders()),
+        properties.getDeliveryMode(),
+        properties.getPriority(),
+        properties.getCorrelationId(),
+        properties.getReplyTo(),
+        properties.getExpiration(),
+        properties.getMessageId(),
+        properties.getTimestamp(),
+        properties.getType(),
+        properties.getUserId(),
+        properties.getAppId(),
+        properties.getClusterId());
+  }
+
+  private static Map<String, Object> parseHeaders(Map<String, Object> headers) {
+    if (headers == null) {
+      return null;
+    }
+    // headers are represented as byte arrays in the AMQP.BasicProperties
+    // we need to convert them to strings
+    Map<String, Object> processedHeaders = new HashMap<>();
+
+    for (Map.Entry<String, Object> entry : headers.entrySet()) {
+      processedHeaders.put(entry.getKey(), handleHeaderValue(entry.getValue()));
+    }
+    return processedHeaders;
+  }
+
+  private static Object handleHeaderValue(Object value) {
+    if (value instanceof LongString longString) {
+      return longString.toString();
+    } else if (value instanceof List<?> list) {
+      return list.stream().map(AMQPPropertyUtil::handleHeaderValue).toList();
+    } else {
+      // long, boolean are represented as their respective types, so we don't need to do anything
+      LOG.debug(
+          "Unhandled header value type: {}. Original value will be returned", value.getClass());
+      return value;
+    }
+  }
+}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumer.java
@@ -19,7 +19,6 @@ import io.camunda.connector.api.inbound.InboundConnectorResult;
 import io.camunda.connector.impl.ConnectorInputException;
 import io.camunda.connector.rabbitmq.inbound.model.RabbitMqInboundResult;
 import io.camunda.connector.rabbitmq.inbound.model.RabbitMqInboundResult.RabbitMqInboundMessage;
-import io.camunda.connector.rabbitmq.inbound.model.RabbitMqMessageProperties;
 import io.camunda.connector.rabbitmq.supplier.GsonSupplier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -112,7 +111,7 @@ public class RabbitMqConsumer extends DefaultConsumer {
       }
       RabbitMqInboundMessage message =
           new RabbitMqInboundMessage(
-              consumerTag, bodyAsObject, new RabbitMqMessageProperties(rawProperties));
+              consumerTag, bodyAsObject, AMQPPropertyUtil.toProperties(rawProperties));
       return new RabbitMqInboundResult(message);
 
     } catch (Exception e) {

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundResult.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundResult.java
@@ -6,97 +6,13 @@
  */
 package io.camunda.connector.rabbitmq.inbound.model;
 
-import com.rabbitmq.client.AMQP;
-import java.util.Objects;
+/**
+ * Model of the Connector output
+ */
+public record RabbitMqInboundResult(RabbitMqInboundMessage message) {
 
-/** Model of the Connector output */
-public class RabbitMqInboundResult {
-  private final RabbitMqInboundMessage message;
-
-  public static class RabbitMqInboundMessage {
-    private final String consumerTag;
-    private final Object body;
-    private final AMQP.BasicProperties properties;
-
-    public RabbitMqInboundMessage(
-        String consumerTag, Object body, AMQP.BasicProperties properties) {
-      this.consumerTag = consumerTag;
-      this.body = body;
-      this.properties = properties;
-    }
-
-    public String getConsumerTag() {
-      return consumerTag;
-    }
-
-    public Object getBody() {
-      return body;
-    }
-
-    public AMQP.BasicProperties getProperties() {
-      return properties;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      RabbitMqInboundMessage that = (RabbitMqInboundMessage) o;
-      return Objects.equals(consumerTag, that.consumerTag)
-          && Objects.equals(body, that.body)
-          && Objects.equals(properties, that.properties);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(consumerTag, body, properties);
-    }
-
-    @Override
-    public String toString() {
-      return "RabbitMqInboundMessage{"
-          + "consumerTag='"
-          + consumerTag
-          + '\''
-          + ", body="
-          + body
-          + ", properties="
-          + properties
-          + '}';
-    }
-  }
-
-  public RabbitMqInboundResult(final RabbitMqInboundMessage message) {
-    this.message = message;
-  }
-
-  public RabbitMqInboundMessage getMessage() {
-    return message;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    RabbitMqInboundResult that = (RabbitMqInboundResult) o;
-    return Objects.equals(message, that.message);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(message);
-  }
-
-  @Override
-  public String toString() {
-    return "RabbitMqInboundResult{" + "message=" + message + '}';
-  }
+  public record RabbitMqInboundMessage(
+      String consumerTag,
+      Object body,
+      RabbitMqMessageProperties properties) {}
 }

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundResult.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqInboundResult.java
@@ -6,13 +6,9 @@
  */
 package io.camunda.connector.rabbitmq.inbound.model;
 
-/**
- * Model of the Connector output
- */
+/** Model of the Connector output */
 public record RabbitMqInboundResult(RabbitMqInboundMessage message) {
 
   public record RabbitMqInboundMessage(
-      String consumerTag,
-      Object body,
-      RabbitMqMessageProperties properties) {}
+      String consumerTag, Object body, RabbitMqMessageProperties properties) {}
 }

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
@@ -7,13 +7,8 @@
 package io.camunda.connector.rabbitmq.inbound.model;
 
 import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.LongString;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Model of the RabbitMQ message properties. Mirrors the {@link AMQP.BasicProperties}. */
 public record RabbitMqMessageProperties(
@@ -30,52 +25,4 @@ public record RabbitMqMessageProperties(
     String type,
     String userId,
     String appId,
-    String clusterId) {
-
-  private static final Logger LOG = LoggerFactory.getLogger(RabbitMqMessageProperties.class);
-
-  public RabbitMqMessageProperties(AMQP.BasicProperties properties) {
-    this(
-        properties.getContentType(),
-        properties.getContentEncoding(),
-        parseHeaders(properties.getHeaders()),
-        properties.getDeliveryMode(),
-        properties.getPriority(),
-        properties.getCorrelationId(),
-        properties.getReplyTo(),
-        properties.getExpiration(),
-        properties.getMessageId(),
-        properties.getTimestamp(),
-        properties.getType(),
-        properties.getUserId(),
-        properties.getAppId(),
-        properties.getClusterId());
-  }
-
-  private static Map<String, Object> parseHeaders(Map<String, Object> headers) {
-    if (headers == null) {
-      return null;
-    }
-    // headers are represented as byte arrays in the AMQP.BasicProperties
-    // we need to convert them to strings
-    Map<String, Object> processedHeaders = new HashMap<>();
-
-    for (Map.Entry<String, Object> entry : headers.entrySet()) {
-      processedHeaders.put(entry.getKey(), handleHeaderValue(entry.getValue()));
-    }
-    return processedHeaders;
-  }
-
-  private static Object handleHeaderValue(Object value) {
-    if (value instanceof LongString longString) {
-      return longString.toString();
-    } else if (value instanceof List<?> list) {
-      return list.stream().map(RabbitMqMessageProperties::handleHeaderValue).toList();
-    } else {
-      // long, boolean are represented as their respective types, so we don't need to do anything
-      LOG.debug(
-          "Unhandled header value type: {}. Original value will be returned", value.getClass());
-      return value;
-    }
-  }
-}
+    String clusterId) {}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
@@ -1,0 +1,78 @@
+package io.camunda.connector.rabbitmq.inbound.model;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.LongString;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Model of the RabbitMQ message properties. Mirrors the {@link AMQP.BasicProperties}.
+ */
+public record RabbitMqMessageProperties(
+    String contentType,
+    String contentEncoding,
+    Map<String, Object> headers,
+    Integer deliveryMode,
+    Integer priority,
+    String correlationId,
+    String replyTo,
+    String expiration,
+    String messageId,
+    Date timestamp,
+    String type,
+    String userId,
+    String appId,
+    String clusterId) {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RabbitMqMessageProperties.class);
+
+  public RabbitMqMessageProperties(AMQP.BasicProperties properties) {
+    this(properties.getContentType(),
+        properties.getContentEncoding(),
+        parseHeaders(properties.getHeaders()),
+        properties.getDeliveryMode(),
+        properties.getPriority(),
+        properties.getCorrelationId(),
+        properties.getReplyTo(),
+        properties.getExpiration(),
+        properties.getMessageId(),
+        properties.getTimestamp(),
+        properties.getType(),
+        properties.getUserId(),
+        properties.getAppId(),
+        properties.getClusterId());
+  }
+
+  private static Map<String, Object> parseHeaders(Map<String, Object> headers) {
+    if (headers == null) {
+      return null;
+    }
+    // headers are represented as byte arrays in the AMQP.BasicProperties
+    // we need to convert them to strings
+    Map<String, Object> processedHeaders = new HashMap<>();
+
+    for (Map.Entry<String, Object> entry : headers.entrySet()) {
+      processedHeaders.put(entry.getKey(), handleHeaderValue(entry.getValue()));
+    }
+    return processedHeaders;
+  }
+
+  private static Object handleHeaderValue(Object value) {
+    if (value instanceof LongString longString) {
+      return longString.toString();
+    } else if (value instanceof List<?> list) {
+      return list.stream()
+          .map(RabbitMqMessageProperties::handleHeaderValue)
+          .toList();
+    } else {
+      // long, boolean are represented as their respective types, so we don't need to do anything
+      LOG.debug("Unhandled header value type: {}. Original value will be returned",
+          value.getClass());
+      return value;
+    }
+  }
+}

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/inbound/model/RabbitMqMessageProperties.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
 package io.camunda.connector.rabbitmq.inbound.model;
 
 import com.rabbitmq.client.AMQP;
@@ -9,9 +15,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Model of the RabbitMQ message properties. Mirrors the {@link AMQP.BasicProperties}.
- */
+/** Model of the RabbitMQ message properties. Mirrors the {@link AMQP.BasicProperties}. */
 public record RabbitMqMessageProperties(
     String contentType,
     String contentEncoding,
@@ -31,7 +35,8 @@ public record RabbitMqMessageProperties(
   private static final Logger LOG = LoggerFactory.getLogger(RabbitMqMessageProperties.class);
 
   public RabbitMqMessageProperties(AMQP.BasicProperties properties) {
-    this(properties.getContentType(),
+    this(
+        properties.getContentType(),
         properties.getContentEncoding(),
         parseHeaders(properties.getHeaders()),
         properties.getDeliveryMode(),
@@ -65,13 +70,11 @@ public record RabbitMqMessageProperties(
     if (value instanceof LongString longString) {
       return longString.toString();
     } else if (value instanceof List<?> list) {
-      return list.stream()
-          .map(RabbitMqMessageProperties::handleHeaderValue)
-          .toList();
+      return list.stream().map(RabbitMqMessageProperties::handleHeaderValue).toList();
     } else {
       // long, boolean are represented as their respective types, so we don't need to do anything
-      LOG.debug("Unhandled header value type: {}. Original value will be returned",
-          value.getClass());
+      LOG.debug(
+          "Unhandled header value type: {}. Original value will be returned", value.getClass());
       return value;
     }
   }

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/AMQPPropertyUtilTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/AMQPPropertyUtilTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.rabbitmq.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.impl.LongStringHelper;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class AMQPPropertyUtilTest {
+
+  @Test
+  void allPropertiesArePresent() {
+    // given
+    BasicProperties properties =
+        new BasicProperties.Builder()
+            .appId("appId")
+            .clusterId("clusterId")
+            .contentEncoding("contentEncoding")
+            .contentType("contentType")
+            .correlationId("correlationId")
+            .deliveryMode(1)
+            .expiration("expiration")
+            .headers(Map.of("key", "value"))
+            .messageId("messageId")
+            .priority(1)
+            .replyTo("replyTo")
+            .timestamp(new Date())
+            .type("type")
+            .userId("userId")
+            .build();
+
+    // when
+    var result = AMQPPropertyUtil.toProperties(properties);
+
+    // then
+    assertThat(result.appId()).isEqualTo(properties.getAppId());
+    assertThat(result.clusterId()).isEqualTo(properties.getClusterId());
+    assertThat(result.contentEncoding()).isEqualTo(properties.getContentEncoding());
+    assertThat(result.contentType()).isEqualTo(properties.getContentType());
+    assertThat(result.correlationId()).isEqualTo(properties.getCorrelationId());
+    assertThat(result.deliveryMode()).isEqualTo(properties.getDeliveryMode());
+    assertThat(result.expiration()).isEqualTo(properties.getExpiration());
+    assertThat(result.headers()).isEqualTo(properties.getHeaders());
+    assertThat(result.messageId()).isEqualTo(properties.getMessageId());
+    assertThat(result.priority()).isEqualTo(properties.getPriority());
+    assertThat(result.replyTo()).isEqualTo(properties.getReplyTo());
+    assertThat(result.timestamp()).isEqualTo(properties.getTimestamp());
+    assertThat(result.type()).isEqualTo(properties.getType());
+    assertThat(result.userId()).isEqualTo(properties.getUserId());
+  }
+
+  @Test
+  void longStringHeader_handledAsRegularString() {
+    // given
+    BasicProperties properties =
+        new BasicProperties.Builder()
+            .headers(Map.of("key", LongStringHelper.asLongString("value")))
+            .build();
+
+    // when
+    var result = AMQPPropertyUtil.toProperties(properties);
+
+    // then
+    assertThat(result.headers().get("key")).isEqualTo("value");
+  }
+
+  @Test
+  void listHeader_handledAsListOfPlainHeaders() {
+    // given
+    BasicProperties properties =
+        new BasicProperties.Builder()
+            .headers(
+                Map.of(
+                    "key",
+                    List.of(
+                        LongStringHelper.asLongString("value1"),
+                        LongStringHelper.asLongString("value2"))))
+            .build();
+
+    // when
+    var result = AMQPPropertyUtil.toProperties(properties);
+
+    // then
+    assertThat(result.headers().get("key")).isEqualTo(List.of("value1", "value2"));
+  }
+
+  @Test
+  void longHeader_handledAsLong() {
+    // given
+    BasicProperties properties = new BasicProperties.Builder().headers(Map.of("key", 1L)).build();
+
+    // when
+    var result = AMQPPropertyUtil.toProperties(properties);
+
+    // then
+    assertThat(result.headers().get("key")).isEqualTo(1L);
+  }
+}

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumerTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/inbound/RabbitMqConsumerTest.java
@@ -70,8 +70,7 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
       var correlatedEvents = context.getCorrelations();
       assertThat(correlatedEvents).hasSize(1);
       assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
-      RabbitMqInboundMessage message =
-          ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+      RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
 
       assertThat(message.body()).isInstanceOf(Map.class);
       Map<String, Object> body = (Map<String, Object>) message.body();
@@ -97,8 +96,7 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
       var correlatedEvents = context.getCorrelations();
       assertThat(correlatedEvents).hasSize(1);
       assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
-      RabbitMqInboundMessage message =
-          ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+      RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
 
       assertThat(message.body()).isInstanceOf(String.class);
       assertThat(message.body()).isEqualTo(body);
@@ -123,8 +121,7 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
       var correlatedEvents = context.getCorrelations();
       assertThat(correlatedEvents).hasSize(1);
       assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
-      RabbitMqInboundMessage message =
-          ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+      RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
 
       assertThat(message.body()).isInstanceOf(Number.class);
       assertThat(((Number) message.body()).intValue()).isEqualTo(Integer.parseInt(body));
@@ -149,8 +146,7 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
       var correlatedEvents = context.getCorrelations();
       assertThat(correlatedEvents).hasSize(1);
       assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
-      RabbitMqInboundMessage message =
-          ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+      RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
 
       assertThat(message.body()).isInstanceOf(Boolean.class);
       assertThat(message.body()).isEqualTo(Boolean.parseBoolean(body));
@@ -165,8 +161,10 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
     void consumer_shouldHandleByteArrayHeaders() throws IOException {
       // Given headers provided as bytes
       Envelope envelope = new Envelope(1, false, "exchange", "routingKey");
-      BasicProperties properties = new BasicProperties.Builder()
-          .headers(Map.of("key", LongStringHelper.asLongString("value"))).build();
+      BasicProperties properties =
+          new BasicProperties.Builder()
+              .headers(Map.of("key", LongStringHelper.asLongString("value")))
+              .build();
 
       // When
       consumer.handleDelivery("consumerTag", envelope, properties, "body".getBytes());
@@ -175,8 +173,7 @@ public class RabbitMqConsumerTest extends InboundBaseTest {
       var correlatedEvents = context.getCorrelations();
       assertThat(correlatedEvents).hasSize(1);
       assertThat(correlatedEvents.get(0)).isInstanceOf(RabbitMqInboundResult.class);
-      RabbitMqInboundMessage message =
-          ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
+      RabbitMqInboundMessage message = ((RabbitMqInboundResult) correlatedEvents.get(0)).message();
 
       assertThat(message.properties().headers().get("key")).isEqualTo("value");
     }

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/integration/RabbitMqIntegrationTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/integration/RabbitMqIntegrationTest.java
@@ -129,9 +129,9 @@ public class RabbitMqIntegrationTest extends BaseTest {
     assertEquals(1, context.getCorrelations().size());
     assertInstanceOf(RabbitMqInboundResult.class, context.getCorrelations().get(0));
     RabbitMqInboundResult castedResult = (RabbitMqInboundResult) context.getCorrelations().get(0);
-    RabbitMqInboundMessage message = castedResult.getMessage();
-    assertInstanceOf(Map.class, message.getBody());
-    Map<String, Object> body = (Map<String, Object>) message.getBody();
+    RabbitMqInboundMessage message = castedResult.message();
+    assertInstanceOf(Map.class, message.body());
+    Map<String, Object> body = (Map<String, Object>) message.body();
     assertEquals("Hello World", body.get("value"));
   }
 


### PR DESCRIPTION
## Description

1. Adds a custom DTO for RabbitMQ message properties to handle header deserialization properly (byte arrays should be handled as strings)
1. Also handles the potential NPE in `RabbitMqConsumer` when correlation result is null

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #709 

