### PR TITLE
feat(aws): standardize region input property

### DIFF
--- a/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsUtils.java
+++ b/connectors/aws/aws-base/src/main/java/io/camunda/connector/aws/AwsUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+package io.camunda.connector.aws;
+
+import io.camunda.connector.aws.model.AwsConfiguration;
+import java.util.Optional;
+import javax.validation.ValidationException;
+
+public class AwsUtils {
+  private AwsUtils() {}
+
+  public static String extractRegionOrDefault(
+      final AwsConfiguration configuration, final String region) {
+    return Optional.ofNullable(configuration)
+        .map(AwsConfiguration::getRegion)
+        .or(() -> Optional.ofNullable(region))
+        .filter(str -> !str.isBlank())
+        .orElseThrow(
+            () ->
+                new ValidationException(
+                    "Found constraints violated while validating input: - configuration.region: must not be empty"));
+  }
+}

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/LambdaConnectorFunction.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/LambdaConnectorFunction.java
@@ -14,13 +14,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.aws.AwsUtils;
 import io.camunda.connector.aws.CredentialsProviderSupport;
 import io.camunda.connector.aws.ObjectMapperSupplier;
-import io.camunda.connector.aws.model.impl.AwsBaseConfiguration;
 import io.camunda.connector.awslambda.model.AwsLambdaRequest;
 import io.camunda.connector.awslambda.model.AwsLambdaResult;
-import io.camunda.connector.impl.ConnectorInputException;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,14 +54,8 @@ public class LambdaConnectorFunction implements OutboundConnectorFunction {
   private InvokeResult invokeLambdaFunction(AwsLambdaRequest request)
       throws JsonProcessingException {
     var region =
-        Optional.ofNullable(request.getConfiguration())
-            .map(AwsBaseConfiguration::getRegion)
-            .or(() -> Optional.ofNullable(request.getAwsFunction().getRegion()))
-            .orElseThrow(
-                () ->
-                    new ConnectorInputException(
-                        new RuntimeException(
-                            "Found constraints violated while validating input: Region is missing.")));
+        AwsUtils.extractRegionOrDefault(
+            request.getConfiguration(), request.getAwsFunction().getRegion());
     final AWSLambda awsLambda =
         awsLambdaSupplier.awsLambdaService(
             CredentialsProviderSupport.credentialsProvider(request), region);

--- a/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
+++ b/connectors/aws/aws-lambda/src/main/java/io/camunda/connector/awslambda/model/FunctionRequestData.java
@@ -17,7 +17,7 @@ public class FunctionRequestData {
   @NotNull private Object payload;
   private OperationType operationType; // this is not use and not implemented yet
 
-  @Secret private String region;
+  @Deprecated @Secret private String region;
 
   public String getFunctionName() {
     return functionName;
@@ -75,10 +75,12 @@ public class FunctionRequestData {
         + '}';
   }
 
+  @Deprecated
   public String getRegion() {
     return region;
   }
 
+  @Deprecated
   public void setRegion(String region) {
     this.region = region;
   }

--- a/connectors/aws/aws-sns/element-templates/aws-sns-connector.json
+++ b/connectors/aws/aws-sns/element-templates/aws-sns-connector.json
@@ -4,7 +4,7 @@
   "id": "io.camunda.connectors.AWSSNS.v1",
   "description": "Send message to topic",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sns/",
-  "version": 1,
+  "version": 2,
   "appliesTo": [
     "bpmn:Task"
   ],
@@ -91,7 +91,7 @@
       "type": "String",
       "binding": {
         "type": "zeebe:input",
-        "name": "topic.region"
+        "name": "configuration.region"
       },
       "constraints": {
         "notEmpty": true

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/SnsConnectorFunction.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.aws.AwsUtils;
 import io.camunda.connector.aws.CredentialsProviderSupport;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.sns.outbound.model.SnsConnectorRequest;
@@ -52,9 +53,10 @@ public class SnsConnectorFunction implements OutboundConnectorFunction {
     final var request = objectMapper.readValue(variables, SnsConnectorRequest.class);
     context.validate(request);
     context.replaceSecrets(request);
-
+    var region =
+        AwsUtils.extractRegionOrDefault(request.getConfiguration(), request.getTopic().getRegion());
     AWSCredentialsProvider provider = CredentialsProviderSupport.credentialsProvider(request);
-    AmazonSNS snsClient = snsClientSupplier.getSnsClient(provider, request.getTopic().getRegion());
+    AmazonSNS snsClient = snsClientSupplier.getSnsClient(provider, region);
     return new SnsConnectorResult(sendMsgToSns(snsClient, request.getTopic()).getMessageId());
   }
 

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/outbound/model/TopicRequestData.java
@@ -20,7 +20,7 @@ import javax.validation.constraints.Size;
 public class TopicRequestData {
 
   @NotBlank @Secret private String topicArn;
-  @NotBlank @Secret private String region;
+  @Deprecated @Secret private String region;
 
   @Size(max = 99)
   private String subject;
@@ -38,10 +38,12 @@ public class TopicRequestData {
     this.topicArn = topicArn;
   }
 
+  @Deprecated
   public String getRegion() {
     return region;
   }
 
+  @Deprecated
   public void setRegion(String region) {
     this.region = region;
   }

--- a/connectors/aws/aws-sns/src/test/resources/requests/fail-test-cases.json
+++ b/connectors/aws/aws-sns/src/test/resources/requests/fail-test-cases.json
@@ -1,11 +1,13 @@
 [
   {
     "testDescription": "No authentication",
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -14,11 +16,13 @@
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -27,11 +31,13 @@
     "authentication":{
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -41,11 +47,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
-      "subject":"MySubject",
-      "region":"us-east-1"
+      "subject":"MySubject"
     }
   },
   {
@@ -67,10 +75,12 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "subject":"MySubject",
       "messageAttributes":{},
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -87,11 +97,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":""
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -101,11 +113,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"   "
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"  ",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
 
     }
@@ -116,11 +130,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
-      "subject":"MySubject",
-      "region":"us-east-1"
+      "subject":"MySubject"
     }
   },
   {
@@ -129,12 +145,14 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "subject":"Test: the proprietary license can be either the Camunda Platform Self-Managed Free Edition license",
       "message":"Hello",
       "messageAttributes":{},
-      "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo",
-      "region":"us-east-1"
+      "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   }
 ]

--- a/connectors/aws/aws-sns/src/test/resources/requests/success-test-cases.json
+++ b/connectors/aws/aws-sns/src/test/resources/requests/success-test-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "testDescription": "Request with secrets",
+    "testDescription": "Deprecated case where region in topic, but must be supported",
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
@@ -14,10 +14,29 @@
     }
   },
   {
+    "testDescription": "Request with secrets",
+    "authentication":{
+      "secretKey":"secrets.AWS_SECRET_KEY",
+      "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
+    },
+    "topic":{
+      "message":"Hello",
+      "messageAttributes":{},
+      "subject":"MySubject",
+      "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
+    }
+  },
+  {
     "testDescription": "Request with attributes",
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "topic":{
       "message":"Hello",
@@ -32,7 +51,6 @@
         }
       },
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"secrets.AWS_TOPIC_ARN"
     }
   },
@@ -42,10 +60,12 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"secrets.AWS_TOPIC_ARN"
     }
   },
@@ -55,11 +75,13 @@
       "secretKey":"AAAABBBBCCCDDD",
       "accessKey":"4W553CR3TK3Y"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -69,11 +91,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"us-east-1",
       "topicArn":"secrets.AWS_TOPIC_ARN"
     }
   },
@@ -83,11 +107,13 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"secrets.AWS_TOPIC_REGION"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
       "subject":"MySubject",
-      "region":"secrets.AWS_TOPIC_REGION",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   },
@@ -97,10 +123,12 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "topic":{
       "message":"Hello",
       "messageAttributes":{},
-      "region":"us-east-1",
       "topicArn":"arn:aws:sns:us-east-1:036433529947:MyCamundaDemo"
     }
   }

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Amazon SQS connector",
   "id": "io.camunda.connectors.AWSSQS.v1",
-  "version": 2,
+  "version": 3,
   "description": "Send message to queue",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs/",
   "appliesTo": [
@@ -95,7 +95,7 @@
       "type": "String",
       "binding": {
         "type": "zeebe:input",
-        "name": "queue.region"
+        "name": "configuration.region"
       },
       "constraints": {
         "notEmpty": true

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-inbound-intermediate-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Amazon SQS connector",
   "id": "io.camunda.connectors.AWSSQS.intermediate.v1",
-  "version": 1,
+  "version": 2,
   "description": "Receive message from a queue",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/",
   "appliesTo": [
@@ -112,7 +112,7 @@
       "type": "String",
       "binding": {
         "type": "zeebe:property",
-        "name": "queue.region"
+        "name": "configuration.region"
       },
       "constraints": {
         "notEmpty": true

--- a/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
+++ b/connectors/aws/aws-sqs/element-templates/aws-sqs-start-event-connector.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Amazon SQS connector",
   "id": "io.camunda.connectors.AWSSQS.StartEvent.v1",
-  "version": 1,
+  "version": 2,
   "description": "Receive message from a queue",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/aws-sqs-inbound/",
   "appliesTo": [
@@ -100,7 +100,7 @@
       "type": "String",
       "binding": {
         "type": "zeebe:property",
-        "name": "queue.region"
+        "name": "configuration.region"
       },
       "constraints": {
         "notEmpty": true

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/SqsExecutable.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.inbound.InboundConnectorExecutable;
+import io.camunda.connector.aws.AwsUtils;
 import io.camunda.connector.aws.CredentialsProviderSupport;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
 import io.camunda.connector.common.suppliers.DefaultAmazonSQSClientSupplier;
@@ -49,11 +50,12 @@ public class SqsExecutable implements InboundConnectorExecutable {
 
     context.replaceSecrets(properties);
     context.validate(properties);
-
+    var region =
+        AwsUtils.extractRegionOrDefault(
+            properties.getConfiguration(), properties.getQueue().getRegion());
     amazonSQS =
         sqsClientSupplier.sqsClient(
-            CredentialsProviderSupport.credentialsProvider(properties),
-            properties.getQueue().getRegion());
+            CredentialsProviderSupport.credentialsProvider(properties), region);
     LOGGER.debug("SQS client created successfully");
     if (sqsQueueConsumer == null) {
       sqsQueueConsumer = new SqsQueueConsumer(amazonSQS, properties, context);

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/inbound/model/SqsInboundQueueProperties.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
 public class SqsInboundQueueProperties {
-  @NotEmpty @Secret private String region;
+  @Deprecated @Secret private String region;
   @NotEmpty @Secret private String url;
   @Secret private List<String> attributeNames;
   @Secret private List<String> messageAttributeNames;
@@ -22,10 +22,12 @@ public class SqsInboundQueueProperties {
   @Secret
   private String pollingWaitTime;
 
+  @Deprecated
   public String getRegion() {
     return region;
   }
 
+  @Deprecated
   public void setRegion(final String region) {
     this.region = region;
   }

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/SqsConnectorFunction.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/SqsConnectorFunction.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
+import io.camunda.connector.aws.AwsUtils;
 import io.camunda.connector.aws.CredentialsProviderSupport;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.common.suppliers.AmazonSQSClientSupplier;
@@ -54,7 +55,10 @@ public class SqsConnectorFunction implements OutboundConnectorFunction {
     context.replaceSecrets(request);
 
     AWSCredentialsProvider provider = CredentialsProviderSupport.credentialsProvider(request);
-    AmazonSQS sqsClient = sqsClientSupplier.sqsClient(provider, request.getQueue().getRegion());
+
+    var region =
+        AwsUtils.extractRegionOrDefault(request.getConfiguration(), request.getQueue().getRegion());
+    AmazonSQS sqsClient = sqsClientSupplier.sqsClient(provider, region);
     return new SqsConnectorResult(sendMsgToSqs(sqsClient, request.getQueue()).getMessageId());
   }
 

--- a/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
+++ b/connectors/aws/aws-sqs/src/main/java/io/camunda/connector/outbound/model/QueueRequestData.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.NotNull;
 public class QueueRequestData {
 
   @NotEmpty @Secret private String url;
-  @NotEmpty @Secret private String region;
+  @Deprecated @Secret private String region;
 
   @NotNull private Object messageBody;
 
@@ -41,10 +41,12 @@ public class QueueRequestData {
     this.url = url;
   }
 
+  @Deprecated
   public String getRegion() {
     return region;
   }
 
+  @Deprecated
   public void setRegion(String region) {
     this.region = region;
   }

--- a/connectors/aws/aws-sqs/src/test/resources/requests/inbound/success-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/inbound/success-test-cases.json
@@ -1,20 +1,6 @@
 [
   {
-    "testDescription": "Request with secrets",
-    "authentication":{
-      "secretKey":"secrets.AWS_SECRET_KEY",
-      "accessKey":"secrets.AWS_ACCESS_KEY"
-    },
-    "queue":{
-      "attributeNames":["{{secrets.ATTRIBUTE_NAME_KEY}}"],
-      "messageAttributeNames": ["{{secrets.MESSAGE_ATTRIBUTE_NAME_KEY}"],
-      "region":"us-east-1",
-      "url":"secrets.SQS_QUEUE_URL",
-      "pollingWaitTime": "1"
-    }
-  },
-  {
-    "testDescription": "Request without secrets and attributes",
+    "testDescription": "Deprecated test, should support region in queue",
     "authentication":{
       "secretKey":"AAAABBBBCCCDDD",
       "accessKey":"4W553CR3TK3Y"
@@ -29,13 +15,48 @@
     }
   },
   {
+    "testDescription": "Request with secrets",
+    "authentication":{
+      "secretKey":"secrets.AWS_SECRET_KEY",
+      "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
+    },
+    "queue":{
+      "attributeNames":["{{secrets.ATTRIBUTE_NAME_KEY}}"],
+      "messageAttributeNames": ["{{secrets.MESSAGE_ATTRIBUTE_NAME_KEY}"],
+      "url":"secrets.SQS_QUEUE_URL",
+      "pollingWaitTime": "1"
+    }
+  },
+  {
+    "testDescription": "Request without secrets and attributes",
+    "authentication":{
+      "secretKey":"AAAABBBBCCCDDD",
+      "accessKey":"4W553CR3TK3Y"
+    },
+    "configuration": {
+      "region":"us-east-1"
+    },
+    "queue":{
+      "messageAttributes":{},
+      "attributeNames":["attribute"],
+      "messageAttributeNames": ["messageAttributeName"],
+      "url":"https://my.queue.url",
+      "pollingWaitTime": "1"
+    }
+  },
+  {
     "testDescription": "Request with secrets, without attributes",
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
-      "region":"us-east-1",
       "url":"secrets.SQS_QUEUE_URL",
       "pollingWaitTime": "1"
     }
@@ -46,8 +67,10 @@
       "secretKey":"AAAABBBBCCCDDD",
       "accessKey":"4W553CR3TK3Y"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
-      "region":"us-east-1",
       "url":"https://my.queue.url",
       "pollingWaitTime": "1"
     }

--- a/connectors/aws/aws-sqs/src/test/resources/requests/outbound/fail-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/outbound/fail-test-cases.json
@@ -1,6 +1,9 @@
 [
   {
     "testDescription": "No authentication",
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
       "messageAttributes":{},
       "messageBody":{
@@ -14,6 +17,9 @@
     "testDescription": "No access key",
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue":{
       "messageAttributes":{},
@@ -29,6 +35,9 @@
     "authentication":{
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
       "messageAttributes":{},
       "messageBody":{
@@ -43,6 +52,9 @@
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue":{
       "messageAttributes":{},
@@ -72,6 +84,9 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
       "messageAttributes":{},
       "region":"us-east-1",
@@ -91,6 +106,9 @@
       "secretKey": "secrets.AWS_SECRET_KEY",
       "accessKey": "secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue": {
       "type": "fifo",
       "messageDeduplicationId": "messageDeduplicationId",
@@ -107,6 +125,9 @@
     "authentication": {
       "secretKey": "secrets.AWS_SECRET_KEY",
       "accessKey": "secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue": {
       "type": null,
@@ -125,6 +146,9 @@
     "authentication": {
       "secretKey": "secrets.AWS_SECRET_KEY",
       "accessKey": "secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue": {
       "type": "standard",

--- a/connectors/aws/aws-sqs/src/test/resources/requests/outbound/success-test-cases.json
+++ b/connectors/aws/aws-sqs/src/test/resources/requests/outbound/success-test-cases.json
@@ -1,6 +1,6 @@
 [
   {
-    "testDescription": "Request with secrets",
+    "testDescription": "deprecated case, but region must support in queue too",
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
@@ -15,17 +15,36 @@
     }
   },
   {
-    "testDescription": "Request without secrets",
+    "testDescription": "Request with secrets",
     "authentication":{
-      "secretKey":"AAAABBBBCCCDDD",
-      "accessKey":"4W553CR3TK3Y"
+      "secretKey":"secrets.AWS_SECRET_KEY",
+      "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue":{
       "messageAttributes":{},
       "messageBody":{
         "data":"ok"
       },
-      "region":"us-east-1",
+      "url":"secrets.SQS_QUEUE_URL"
+    }
+  },
+  {
+    "testDescription": "Request without secrets",
+    "authentication":{
+      "secretKey":"AAAABBBBCCCDDD",
+      "accessKey":"4W553CR3TK3Y"
+    },
+    "configuration": {
+      "region":"us-east-1"
+    },
+    "queue":{
+      "messageAttributes":{},
+      "messageBody":{
+        "data":"ok"
+      },
       "url":"https://my.queue.url"
     }
   },
@@ -34,6 +53,9 @@
     "authentication":{
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
+    },
+    "configuration": {
+      "region":"us-east-1"
     },
     "queue":{
       "messageAttributes":{
@@ -49,7 +71,6 @@
       "messageBody":{
         "data":"ok"
       },
-      "region":"us-east-1",
       "url":"secrets.SQS_QUEUE_URL"
     }
   },
@@ -59,6 +80,9 @@
       "secretKey":"secrets.AWS_SECRET_KEY",
       "accessKey":"secrets.AWS_ACCESS_KEY"
     },
+    "configuration": {
+      "region":"us-east-1"
+    },
     "queue":{
       "type": "fifo",
       "messageGroupId": "messageGroupId",
@@ -67,7 +91,6 @@
       "messageBody":{
         "data":"ok"
       },
-      "region":"us-east-1",
       "url":"secrets.SQS_QUEUE_URL"
     }
   }


### PR DESCRIPTION
## Description

Introduce a backwards compatible layer for the previously used connector request config that maps to the new AWSBaseRequest based config.

## Related issues

https://github.com/camunda/connectors-bundle/issues/673

