### PR TITLE
fix docker build context

### DIFF
--- a/bundle/default-bundle/Dockerfile
+++ b/bundle/default-bundle/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /opt/app
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Using the start script from the base connector runtime image
-COPY ../../connector-runtime/connector-runtime-application/start.sh /start.sh
+COPY start.sh /start.sh
 RUN chmod +x start.sh
 
 ENTRYPOINT ["/start.sh"]

--- a/bundle/default-bundle/Dockerfile-focal
+++ b/bundle/default-bundle/Dockerfile-focal
@@ -4,7 +4,7 @@ RUN mkdir /opt/app
 COPY target/*-with-dependencies.jar /opt/app/
 
 # Using the start script from the base connector runtime image
-COPY ../../connector-runtime/connector-runtime-application/start.sh /start.sh
+COPY start.sh /start.sh
 RUN chmod +x start.sh
 
 ENTRYPOINT ["/start.sh"]

--- a/bundle/default-bundle/start.sh
+++ b/bundle/default-bundle/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+JAVA_OPTS="${JAVA_OPTS}"
+
+# Explicitly set trust store location
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTORE}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVAX_NET_SSL_TRUSTSTORE}"
+fi
+
+# Explicitly set trust store password
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}"
+fi
+
+if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
+  echo "Applied JVM options: $JAVA_OPTS"
+fi
+
+exec java ${JAVA_OPTS} -cp '/opt/app/*' "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"


### PR DESCRIPTION
## Description

Restored the `start.sh` file that was removed in the previous PR. The expectation was that we can reuse the `start.sh` from `connector-runtime/connector-runtime-application`, but this causes troubles: docker build context needs to be set to the root dir, and other paths need to be adjusted accordingly (`target` folder with build results).

Note: the drawback of the chosen solution is that we will have 2 identical `build.sh` files. We can think how to resolve this iteratively.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

