### PR TITLE
fix: restore local connector runtime in the default bundle

### DIFF
--- a/bundle/default-bundle/README.md
+++ b/bundle/default-bundle/README.md
@@ -1,6 +1,6 @@
 Run via Maven / IDE:
 
-Run `LocalConnectorRuntime` class via your favorite IDE.
+Run `io.camunda.coonnector.runtime.app.LocalConnectorRuntime` class via your favorite IDE.
 You can add an `application.properties` file to `src/test/resources` containing your configurations.
 
 Run via command line

--- a/bundle/default-bundle/src/test/java/io/camunda/coonnector/runtime/app/LocalConnectorRuntime.java
+++ b/bundle/default-bundle/src/test/java/io/camunda/coonnector/runtime/app/LocalConnectorRuntime.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.coonnector.runtime.app;
+
+import io.camunda.connector.runtime.app.ConnectorRuntimeApplication;
+import org.springframework.boot.SpringApplication;
+
+public class LocalConnectorRuntime {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ConnectorRuntimeApplication.class, args);
+  }
+}

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -15,7 +15,7 @@ mvn clean verify
 Use the [Camunda Connector Runtime](https://github.com/camunda-community-hub/spring-zeebe/tree/master/connector-runtime#building-connector-runtime-bundles) to run your function as a local Java application.
 
 In your IDE you can also simply navigate to the
-[LocalContainerRuntime](../bundle/default-bundle/src/test/java/io/camunda/connector/bundle/LocalConnectorRuntime.java)
+[LocalContainerRuntime](../bundle/default-bundle/src/test/java/io/camunda/connector/bundle/io.camunda.coonnector.runtime.app.LocalConnectorRuntime.java)
 class in test scope of the `default-bundle` module and run it via your IDE.
 
 ## Element Template


### PR DESCRIPTION
## Description

Adds an alternative simple way to run the runtime locally, as previously used main class was deleted.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

