### PR TITLE
feat: make graphql.headers optional element template

### DIFF
--- a/connectors/graphql/element-templates/graphql-connector.json
+++ b/connectors/graphql/element-templates/graphql-connector.json
@@ -126,6 +126,7 @@
       "group": "endpoint",
       "type": "Text",
       "feel": "required",
+      "optional": true,
       "binding": {
         "type": "zeebe:input",
         "name": "graphql.headers"


### PR DESCRIPTION
## Description

Element template had to be changed to make headers optional. Although it was not required without this addition deploy fails if headers textfield is empty.

## Related issues

closes #
https://github.com/camunda/connectors-bundle/issues/841 

