### PR TITLE
fix(rabbitmq): fix outbound serialization by switching to jackson

### DIFF
--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -25,6 +25,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- TODO: for removal -->
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqMessage.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqMessage.java
@@ -6,12 +6,12 @@
  */
 package io.camunda.connector.rabbitmq.common.model;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonSyntaxException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP;
-import io.camunda.connector.api.annotation.Secret;
 import io.camunda.connector.rabbitmq.outbound.ValidationPropertiesUtil;
-import io.camunda.connector.rabbitmq.supplier.GsonSupplier;
 import java.util.Objects;
 import java.util.Optional;
 import javax.validation.constraints.NotNull;
@@ -21,31 +21,35 @@ import org.slf4j.LoggerFactory;
 
 public class RabbitMqMessage {
   private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMqMessage.class);
-  @Secret private Object properties;
-  @NotNull @Secret private Object body;
+  private static final ObjectMapper mapper = new ObjectMapper()
+      .findAndRegisterModules()
+      .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+
+  private Object properties;
+  @NotNull private Object body;
 
   public AMQP.BasicProperties getPropertiesAsAmqpBasicProperties() {
     return Optional.ofNullable(properties)
-        .map(GsonSupplier.gson()::toJsonTree)
+        .map(properties -> mapper.convertValue(properties, JsonNode.class))
         .map(ValidationPropertiesUtil::validateAmqpBasicPropertiesOrThrowException)
         .map(
             jsonProperties ->
-                GsonSupplier.gson().fromJson(jsonProperties, AMQP.BasicProperties.class))
+                mapper.convertValue(jsonProperties, AMQP.BasicProperties.class))
         .orElse(null);
   }
 
   public byte[] getBodyAsByteArray() {
     if (body instanceof String) {
       try {
-        JsonElement jsonElement =
-            GsonSupplier.gson()
-                .fromJson(StringEscapeUtils.unescapeJson(body.toString()), JsonElement.class);
-        if (jsonElement.isJsonPrimitive()) {
+        JsonNode jsonElement =
+            mapper.readTree(StringEscapeUtils.unescapeJson(body.toString()));
+
+        if (jsonElement.isValueNode()) {
           return ((String) body).getBytes();
         } else {
           body = jsonElement;
         }
-      } catch (JsonSyntaxException e) {
+      } catch (JsonProcessingException e) {
         // this is plain text value, and not JSON. For example, "some input text".
         LOGGER.debug("Expected exception when parsing a plain text value : {}", body, e);
         return body.toString().getBytes();
@@ -53,7 +57,13 @@ public class RabbitMqMessage {
     }
 
     return Optional.of(body)
-        .map(GsonSupplier.gson()::toJson)
+        .map(body -> {
+          try {
+            return mapper.writeValueAsString(body);
+          } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+          }
+        })
         .map(StringEscapeUtils::unescapeJson)
         .map(String::getBytes)
         .orElseThrow(() -> new RuntimeException("Parse error to byte array"));

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/ValidationPropertiesUtil.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/ValidationPropertiesUtil.java
@@ -6,20 +6,21 @@
  */
 package io.camunda.connector.rabbitmq.outbound;
 
-import com.google.gson.JsonElement;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.rabbitmq.client.AMQP;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
 public final class ValidationPropertiesUtil {
 
   private ValidationPropertiesUtil() {}
 
   // return the input object without changing, only validation
-  public static JsonElement validateAmqpBasicPropertiesOrThrowException(JsonElement jsonElement) {
-    Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-    for (Map.Entry<String, JsonElement> entry : entries) {
+  public static JsonNode validateAmqpBasicPropertiesOrThrowException(JsonNode jsonElement) {
+    Iterator<Entry<String, JsonNode>> entries = jsonElement.fields();
+    while(entries.hasNext()) {
+      Entry<String, JsonNode> entry = entries.next();
       boolean fieldExist =
           Arrays.stream(AMQP.BasicProperties.class.getDeclaredFields())
               .anyMatch(f -> f.getName().equals(entry.getKey()));

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqRequest.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/outbound/model/RabbitMqRequest.java
@@ -6,7 +6,6 @@
  */
 package io.camunda.connector.rabbitmq.outbound.model;
 
-import io.camunda.connector.api.annotation.Secret;
 import io.camunda.connector.rabbitmq.common.model.RabbitMqAuthentication;
 import io.camunda.connector.rabbitmq.common.model.RabbitMqAuthenticationType;
 import io.camunda.connector.rabbitmq.common.model.RabbitMqMessage;
@@ -17,9 +16,9 @@ import javax.validation.constraints.NotNull;
 
 public class RabbitMqRequest {
 
-  @Valid @NotNull @Secret private RabbitMqAuthentication authentication;
-  @Valid @NotNull @Secret private RabbitMqOutboundRouting routing;
-  @Valid @NotNull @Secret private RabbitMqMessage message;
+  @Valid @NotNull private RabbitMqAuthentication authentication;
+  @Valid @NotNull private RabbitMqOutboundRouting routing;
+  @Valid @NotNull private RabbitMqMessage message;
 
   @AssertFalse
   private boolean isRoutingParamsNotFilling() {

--- a/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/ValidationPropertiesUtilTest.java
+++ b/connectors/rabbitmq/src/test/java/io/camunda/connector/rabbitmq/outbound/ValidationPropertiesUtilTest.java
@@ -9,28 +9,32 @@ package io.camunda.connector.rabbitmq.outbound;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ValidationPropertiesUtilTest extends OutboundBaseTest {
 
+  private final ObjectMapper mapper = new ObjectMapper();
+
   @Test
   public void validateAmqpBasicPropertiesOrThrowException_shouldReturnSameObjectWithoutChanging() {
     // given json object with properties
-    JsonObject expected = new JsonObject();
-    JsonObject headers = new JsonObject();
-    headers.addProperty("header", "value");
-    expected.addProperty("userId", "1234");
-    expected.addProperty("appId", "123456");
-    expected.addProperty("contentEncoding", "UTF-8");
-    expected.addProperty("contentType", "json");
-    expected.addProperty("messageId", "00000001");
-    expected.add("headers", headers);
+    ObjectNode expected = mapper.createObjectNode();
+    ObjectNode headers = mapper.createObjectNode();
+    headers.set("header", mapper.convertValue("value", JsonNode.class));
+    expected.set("userId", mapper.convertValue("1234", JsonNode.class));
+    expected.set("appId", mapper.convertValue("123456", JsonNode.class));
+    expected.set("contentEncoding", mapper.convertValue("UTF-8", JsonNode.class));
+    expected.set("contentType", mapper.convertValue("json", JsonNode.class));
+    expected.set("messageId", mapper.convertValue("00000001", JsonNode.class));
+    expected.set("headers", headers);
     // when do validation
-    JsonElement actual =
+    com.fasterxml.jackson.databind.JsonNode actual =
         ValidationPropertiesUtil.validateAmqpBasicPropertiesOrThrowException(expected);
     // then expected that method return object without changing
     assertThat(expected).isEqualTo(actual);
@@ -39,9 +43,9 @@ class ValidationPropertiesUtilTest extends OutboundBaseTest {
   @ParameterizedTest
   @MethodSource("failPropertiesFieldValidationTest")
   void validateAmqpBasicPropertiesOrThrowException_shouldThrowExceptionWhenNameOfPropertyNotIsWrong(
-      String input) {
+      String input) throws JsonProcessingException {
     // Given request with wrong name of properties field
-    JsonElement properties = gson.fromJson(input, JsonElement.class);
+    JsonNode properties = mapper.readTree(input);
     // When validated properties object we check jsonElement with AMQP.BasicProperties
     // Then expect IllegalArgumentException "Unsupported field <field name> for properties"
     IllegalArgumentException thrown =


### PR DESCRIPTION
## Description

Because we started using Jackson for variables deserialization, the gson instance used by the outbound RabbitMQ connector to serialize the message body again started to produce bad serialization results.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

