### PR TITLE
fix(rest): add necessary jackson modules to http proxy service

### DIFF
--- a/connectors/connectors-common-library/pom.xml
+++ b/connectors/connectors-common-library/pom.xml
@@ -36,7 +36,18 @@ limitations under the License.</license.inlineheader>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
 
         <dependency>

--- a/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPProxyService.java
+++ b/connectors/connectors-common-library/src/main/java/io/camunda/connector/common/services/HTTPProxyService.java
@@ -18,6 +18,10 @@ package io.camunda.connector.common.services;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import com.google.api.client.http.AbstractHttpContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
@@ -38,7 +42,13 @@ public final class HTTPProxyService {
   private static final Logger LOG = LoggerFactory.getLogger(HTTPProxyService.class);
 
   private static final ObjectMapper objectMapper =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          // deserialize unknown types as empty objects
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   public static HttpRequest toRequestViaProxy(
       final HttpRequestFactory requestFactory,


### PR DESCRIPTION
## Description

Sending a request with an empty body via REST connector results in the following body received by webhook.site:

<img width="311" alt="Screenshot 2023-07-10 at 17 18 01" src="https://github.com/camunda/connectors-bundle/assets/38818382/a8c950b5-4346-473e-9838-054b5fb02374">

This is due to a missing Jackson Scala module: FEEL expression gets deserialized as some kind of special Scala map implementation that can't be handled properly by default in Jackson. This is only reproducible when running with a proxy function.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

