### PR TITLE
fix(rabbitmq): edit default properties value to start from '='

### DIFF
--- a/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
+++ b/connectors/rabbitmq/element-templates/rabbitmq-outbound-connector.json
@@ -218,7 +218,7 @@
       "group": "message",
       "type": "Text",
       "feel": "required",
-      "value": "{}",
+      "value": "={}",
       "binding": {
         "type": "zeebe:input",
         "name": "message.properties"


### PR DESCRIPTION
## Description

We force this field to be a FEEL expression, but provide the default value without `=`. Web modeler does not implicitly add an equals sign, and we can't deserialize the properties into an object because it arrives to us as a string.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

