### PR TITLE
fix kafka value serialization; change group id property to include elementId and processDefinitionKey

### DIFF
--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -57,6 +57,15 @@ except in compliance with the proprietary license.</license.inlineheader>
       <artifactId>kafka</artifactId>
       <version>${version.testcontainers}</version>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_3</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/inbound/KafkaExecutableTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.connector.kafka.outbound.model.KafkaTopic;
 import io.camunda.connector.test.inbound.InboundConnectorContextBuilder;
 import io.camunda.connector.test.inbound.InboundConnectorDefinitionBuilder;
@@ -145,7 +147,13 @@ public class KafkaExecutableTest {
         DEFAULT_KEY_DESERIALIZER, properties.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
     assertEquals(false, properties.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG));
     assertEquals(
-        "kafka-inbound-connector-" + processId, properties.get(ConsumerConfig.GROUP_ID_CONFIG));
+        "kafka-inbound-connector-"
+            + context.getDefinition().bpmnProcessId()
+            + "-"
+            + context.getDefinition().elementId()
+            + "-"
+            + context.getDefinition().processDefinitionKey(),
+        properties.get(ConsumerConfig.GROUP_ID_CONFIG));
   }
 
   @ParameterizedTest
@@ -176,8 +184,8 @@ public class KafkaExecutableTest {
     // Then
     assertEquals("my-key", kafkaInboundMessage.getKey());
     assertEquals("{\"foo\": \"bar\"}", kafkaInboundMessage.getRawValue());
-    Map<String, Object> expectedValue = new HashMap<>();
-    expectedValue.put("foo", "bar");
+    ObjectNode expectedValue = JsonNodeFactory.instance.objectNode();
+    expectedValue.set("foo", JsonNodeFactory.instance.textNode("bar"));
     assertEquals(expectedValue, kafkaInboundMessage.getValue());
   }
 

--- a/connectors/kafka/src/test/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunctionTest.java
+++ b/connectors/kafka/src/test/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunctionTest.java
@@ -93,15 +93,22 @@ class KafkaConnectorFunctionTest {
 
     var request = ctx.bindVariables(KafkaConnectorRequest.class);
 
+    String transformedValue =
+        request.getMessage().getValue() instanceof String
+            ? (String) request.getMessage().getValue()
+            : objectMapper.writeValueAsString(request.getMessage().getValue());
+
     // then
     // Testing records are equal
     Mockito.verify(producer).send(producerRecordCaptor.capture());
     ProducerRecord recordActual = producerRecordCaptor.getValue();
+    String expectedValue =
+        request.getMessage().getValue() instanceof String
+            ? (String) request.getMessage().getValue()
+            : objectMapper.writeValueAsString(request.getMessage().getValue());
     ProducerRecord recordExpected =
         new ProducerRecord(
-            request.getTopic().getTopicName(),
-            request.getMessage().getKey(),
-            request.getMessage().getValue());
+            request.getTopic().getTopicName(), request.getMessage().getKey(), expectedValue);
     assertThat(recordActual.toString()).isEqualTo(recordExpected.toString());
 
     // Testing secrets updated


### PR DESCRIPTION
## Description

Bug was found in Kafka serialization, which had to be fixed.  Now it converts FEEL expression (which represented as a scala Map) properly to json.

