### PR TITLE
Standardize jackson configuration

### DIFF
--- a/connectors/connectors-common-library/pom.xml
+++ b/connectors/connectors-common-library/pom.xml
@@ -34,23 +34,6 @@ limitations under the License.</license.inlineheader>
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.danilopianini</groupId>
             <artifactId>gson-extras</artifactId>
         </dependency>

--- a/connectors/google/google-base/pom.xml
+++ b/connectors/google/google-base/pom.xml
@@ -27,10 +27,6 @@
     </licenses>
 
     <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -31,10 +31,6 @@ except in compliance with the proprietary license.</license.inlineheader>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -61,10 +57,6 @@ except in compliance with the proprietary license.</license.inlineheader>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-scala_3</artifactId>
     </dependency>
   </dependencies>
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/inbound/KafkaPropertyTransformer.java
@@ -9,6 +9,10 @@ package io.camunda.connector.kafka.inbound;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.kafka.outbound.model.KafkaConnectorRequest;
 import java.util.ArrayList;
@@ -29,10 +33,15 @@ public class KafkaPropertyTransformer {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaPropertyTransformer.class);
 
-  private static ObjectMapper objectMapper =
+  private static final ObjectMapper objectMapper =
       new ObjectMapper()
-          .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
-          .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          // deserialize unknown types as empty objects
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
 
   static final String DEFAULT_GROUP_ID_PREFIX = "kafka-inbound-connector";
 

--- a/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
+++ b/connectors/kafka/src/main/java/io/camunda/connector/kafka/outbound/KafkaConnectorFunction.java
@@ -6,7 +6,11 @@
  */
 package io.camunda.connector.kafka.outbound;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.error.ConnectorException;
@@ -32,7 +36,12 @@ public class KafkaConnectorFunction implements OutboundConnectorFunction {
   private final Function<Properties, Producer> producerCreatorFunction;
 
   private static final ObjectMapper objectMapper =
-      new ObjectMapper().registerModule(DefaultScalaModule$.MODULE$);
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   public KafkaConnectorFunction() {
     this(KafkaProducer::new);

--- a/connectors/microsoft-teams/pom.xml
+++ b/connectors/microsoft-teams/pom.xml
@@ -24,7 +24,6 @@
   </licenses>
 
   <dependencies>
-
     <dependency>
       <groupId>com.microsoft.graph</groupId>
       <artifactId>microsoft-graph</artifactId>

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
@@ -9,6 +9,8 @@ package io.camunda.connector.suppliers;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 
@@ -19,7 +21,10 @@ public final class ObjectMapperSupplier {
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
           .registerModule(DefaultScalaModule$.MODULE$)
           .registerModule(new JavaTimeModule())
-          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+          .registerModule(new Jdk8Module())
+          .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private ObjectMapperSupplier() {}
 

--- a/connectors/microsoft-teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
+++ b/connectors/microsoft-teams/src/main/java/io/camunda/connector/suppliers/ObjectMapperSupplier.java
@@ -10,12 +10,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 
 public final class ObjectMapperSupplier {
 
   private static final ObjectMapper objectMapper =
       new ObjectMapper()
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .registerModule(DefaultScalaModule$.MODULE$)
           .registerModule(new JavaTimeModule())
           .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
@@ -64,9 +64,10 @@ class GetChatTest extends BaseTest {
     String chatStringResponse =
         "{\"oDataType\":null,\"id\":\"19:e37f90808e7748d7bbbb2029ed17f643@thread.v2\",\"chatType\":\"GROUP\",\"members\":null,\"messages\":null}";
 
-    ObjectMapper objectMapper = new ObjectMapper()
-        .registerModule(new JavaTimeModule())
-        .registerModule(DefaultScalaModule$.MODULE$);
+    ObjectMapper objectMapper =
+        new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .registerModule(DefaultScalaModule$.MODULE$);
     Chat chat = objectMapper.readValue(chatStringResponse, Chat.class);
 
     when(graphServiceClient.chats(ActualValue.Chat.CHAT_ID)).thenReturn(chatRequestBuilder);

--- a/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
+++ b/connectors/microsoft-teams/src/test/java/io/camunda/connector/model/request/chat/GetChatTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import com.microsoft.graph.models.Chat;
 import com.microsoft.graph.requests.ChatRequest;
 import com.microsoft.graph.requests.ChatRequestBuilder;
@@ -63,7 +64,9 @@ class GetChatTest extends BaseTest {
     String chatStringResponse =
         "{\"oDataType\":null,\"id\":\"19:e37f90808e7748d7bbbb2029ed17f643@thread.v2\",\"chatType\":\"GROUP\",\"members\":null,\"messages\":null}";
 
-    ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .registerModule(DefaultScalaModule$.MODULE$);
     Chat chat = objectMapper.readValue(chatStringResponse, Chat.class);
 
     when(graphServiceClient.chats(ActualValue.Chat.CHAT_ID)).thenReturn(chatRequestBuilder);

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -54,6 +54,24 @@ except in compliance with the proprietary license.</license.inlineheader>
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_3</artifactId>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>io.camunda.connector</groupId>

--- a/connectors/rabbitmq/pom.xml
+++ b/connectors/rabbitmq/pom.xml
@@ -24,10 +24,6 @@
   </licenses>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
     <!-- TODO: for removal -->
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqMessage.java
+++ b/connectors/rabbitmq/src/main/java/io/camunda/connector/rabbitmq/common/model/RabbitMqMessage.java
@@ -10,6 +10,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import com.rabbitmq.client.AMQP;
 import io.camunda.connector.rabbitmq.outbound.ValidationPropertiesUtil;
 import java.util.Objects;
@@ -23,8 +27,11 @@ public class RabbitMqMessage {
   private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMqMessage.class);
   private static final ObjectMapper mapper =
       new ObjectMapper()
-          .findAndRegisterModules()
-          .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private Object properties;
   @NotNull private Object body;

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/suppliers/ObjectMapperSupplier.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/suppliers/ObjectMapperSupplier.java
@@ -15,12 +15,13 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 
 public final class ObjectMapperSupplier {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper()
-      .registerModule(new Jdk8Module())
-      .registerModule(DefaultScalaModule$.MODULE$)
-      .registerModule(new JavaTimeModule())
-      .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private ObjectMapperSupplier() {}
 

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/suppliers/ObjectMapperSupplier.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/suppliers/ObjectMapperSupplier.java
@@ -6,11 +6,21 @@
  */
 package io.camunda.connector.slack.inbound.suppliers;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 
 public final class ObjectMapperSupplier {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper()
+      .registerModule(new Jdk8Module())
+      .registerModule(DefaultScalaModule$.MODULE$)
+      .registerModule(new JavaTimeModule())
+      .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private ObjectMapperSupplier() {}
 

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/utils/ObjectMapperSupplier.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/utils/ObjectMapperSupplier.java
@@ -8,11 +8,20 @@ package io.camunda.connector.inbound.utils;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 
 public final class ObjectMapperSupplier {
 
   private static final ObjectMapper MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(DefaultScalaModule$.MODULE$)
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   private ObjectMapperSupplier() {}
 


### PR DESCRIPTION
## Description

With the recent issues we encountered in several connectors due to missing modules, it makes sense to have the same object mapper config everywhere.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

