### PR TITLE
fix: filter inbound eligible elements before performing 'sanity check'

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
@@ -105,7 +105,7 @@ public class ProcessDefinitionInspector {
             .filter(
                 element -> {
                   Map<String, String> zeebeProperties = getRawProperties(element);
-                  if (zeebeProperties != null && zeebeProperties.get("inbound.type") != null) {
+                  if (zeebeProperties != null && zeebeProperties.get(Keywords.INBOUND_TYPE_KEYWORD) != null) {
                     return true;
                   }
                   return false;

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/importer/ProcessDefinitionInspector.java
@@ -105,7 +105,8 @@ public class ProcessDefinitionInspector {
             .filter(
                 element -> {
                   Map<String, String> zeebeProperties = getRawProperties(element);
-                  if (zeebeProperties != null && zeebeProperties.get(Keywords.INBOUND_TYPE_KEYWORD) != null) {
+                  if (zeebeProperties != null
+                      && zeebeProperties.get(Keywords.INBOUND_TYPE_KEYWORD) != null) {
                     return true;
                   }
                   return false;


### PR DESCRIPTION
## Description

Sometimes we threw a `java.lang.IllegalStateException: Sanity check failed: IntermediateCatchEvent` unnecessary which caused issues.

In the fix we filter the elements to only check those elements which actually have an inbound template applied.

