### PR TITLE
feat(webhook): added response body expression

### DIFF
--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/model/HttpServletRequestWebhookProcessingPayload.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/model/HttpServletRequestWebhookProcessingPayload.java
@@ -27,17 +27,21 @@ public class HttpServletRequestWebhookProcessingPayload implements WebhookProces
 
   private final String requestURL;
   private final String method;
+
+  private final Map<String, Object> body;
   private final Map<String, String> headers;
   private final Map<String, String> params;
   private final byte[] rawBody;
 
   public HttpServletRequestWebhookProcessingPayload(
       final HttpServletRequest httpServletRequest,
+      final Map<String, Object> body,
       final Map<String, String> params,
       final Map<String, String> headers,
       byte[] bodyAsByteArray) {
     this.requestURL = httpServletRequest.getRequestURL().toString();
     this.method = httpServletRequest.getMethod();
+    this.body = body;
     this.headers = headers;
     this.params = params;
     this.rawBody = bodyAsByteArray;
@@ -51,6 +55,11 @@ public class HttpServletRequestWebhookProcessingPayload implements WebhookProces
   @Override
   public String method() {
     return method;
+  }
+
+  @Override
+  public Map<String, Object> body() {
+    return Collections.unmodifiableMap(Optional.ofNullable(body).orElse(Collections.emptyMap()));
   }
 
   @Override

--- a/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/utils/WebUtils.java
+++ b/connector-runtime/connector-runtime-spring/src/main/java/io/camunda/connector/runtime/inbound/webhook/utils/WebUtils.java
@@ -1,0 +1,66 @@
+package io.camunda.connector.runtime.inbound.webhook.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.connector.runtime.core.feel.jackson.JacksonModuleFeelFunction;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public class WebUtils {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper()
+                    //.registerModule(new Jdk8Module())
+                    .registerModule(new JavaTimeModule())
+                    .registerModule(new JacksonModuleFeelFunction())
+                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+
+    WebUtils(){}
+
+    public static String extractContentType(Map<String, String> headers) {
+        var caseInsensitiveMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        caseInsensitiveMap.putAll(headers);
+        return caseInsensitiveMap.getOrDefault(HttpHeaders.CONTENT_TYPE, "").toString();
+    }
+
+    public static Map transformRawBodyToMap(byte[] rawBody, String contentTypeHeader) {
+        if (rawBody == null) {
+            return Collections.emptyMap();
+        }
+
+        if (MediaType.FORM_DATA.toString().equalsIgnoreCase(contentTypeHeader)) {
+            String bodyAsString =
+                    URLDecoder.decode(new String(rawBody, StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+            return Arrays.stream(bodyAsString.split("&"))
+                    .filter(Objects::nonNull)
+                    .map(param -> param.split("="))
+                    .collect(Collectors.toMap(param -> param[0], param -> param.length == 1 ? "" : param[1]));
+        } else {
+            // Do our best to parse to JSON (throws exception otherwise)
+            try {
+                return getMapperInstance().readValue(rawBody, Map.class);
+            } catch (IOException e) {
+                throw new ConnectorException("Couldn't parse content");
+            }
+        }
+    }
+    
+    public static ObjectMapper getMapperInstance() {
+        return MAPPER;
+    }
+}

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -111,6 +111,7 @@ class WebhookControllerTestZeebeTests {
                 new HashMap<>(),
                 "{}".getBytes(),
                 new HashMap<>(),
+                new HashMap<>(),
                 new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
@@ -153,6 +154,7 @@ class WebhookControllerTestZeebeTests {
                 new HashMap<>(),
                 "{}".getBytes(),
                 new HashMap<>(),
+                new HashMap<>(),
                 new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
@@ -182,6 +184,7 @@ class WebhookControllerTestZeebeTests {
             new HashMap<>(),
             "{}".getBytes(),
             new HashMap<>(),
+            new HashMap<>(),
             new MockHttpServletRequest());
     assertEquals(500, responseEntity.getStatusCode().value());
   }
@@ -208,6 +211,7 @@ class WebhookControllerTestZeebeTests {
             "myPath",
             new HashMap<>(),
             "{}".getBytes(),
+            new HashMap<>(),
             new HashMap<>(),
             new MockHttpServletRequest());
 
@@ -238,6 +242,7 @@ class WebhookControllerTestZeebeTests {
                 "myPath",
                 new HashMap<>(),
                 "{}".getBytes(),
+                new HashMap<>(),
                 new HashMap<>(),
                 new MockHttpServletRequest());
 

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -111,7 +111,6 @@ class WebhookControllerTestZeebeTests {
                 new HashMap<>(),
                 "{}".getBytes(),
                 new HashMap<>(),
-                new HashMap<>(),
                 new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
@@ -154,7 +153,6 @@ class WebhookControllerTestZeebeTests {
                 new HashMap<>(),
                 "{}".getBytes(),
                 new HashMap<>(),
-                new HashMap<>(),
                 new MockHttpServletRequest());
 
     assertEquals(200, responseEntity.getStatusCode().value());
@@ -184,7 +182,6 @@ class WebhookControllerTestZeebeTests {
             new HashMap<>(),
             "{}".getBytes(),
             new HashMap<>(),
-            new HashMap<>(),
             new MockHttpServletRequest());
     assertEquals(500, responseEntity.getStatusCode().value());
   }
@@ -211,7 +208,6 @@ class WebhookControllerTestZeebeTests {
             "myPath",
             new HashMap<>(),
             "{}".getBytes(),
-            new HashMap<>(),
             new HashMap<>(),
             new MockHttpServletRequest());
 
@@ -242,7 +238,6 @@ class WebhookControllerTestZeebeTests {
                 "myPath",
                 new HashMap<>(),
                 "{}".getBytes(),
-                new HashMap<>(),
                 new HashMap<>(),
                 new MockHttpServletRequest());
 

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -37,6 +37,10 @@
     {
       "id": "variable-mapping",
       "label": "Variable mapping"
+    },
+    {
+      "id": "webhookResponse",
+      "label": "Webhook response"
     }
   ],
   "properties": [
@@ -423,6 +427,18 @@
         "name": "resultExpression"
       },
       "description": "Expression to map the inbound payload to process variables"
+    },
+    {
+      "label": "Response body expression",
+      "type": "Text",
+      "group": "webhookResponse",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.responseBodyExpression"
+      },
+      "description": "Specify condition and response"
     }
   ],
   "icon": {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook connector",
   "id": "io.camunda.connectors.webhook.WebhookConnector.v1",
-  "version": 5,
+  "version": 6,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {
@@ -35,6 +35,10 @@
     {
       "id": "variable-mapping",
       "label": "Variable mapping"
+    },
+    {
+      "id": "webhookResponse",
+      "label": "Webhook response"
     }
   ],
   "properties": [
@@ -383,6 +387,18 @@
         "name": "resultExpression"
       },
       "description": "Expression to map the inbound payload to process variables"
+    },
+    {
+      "label": "Response body expression",
+      "type": "Text",
+      "group": "webhookResponse",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.responseBodyExpression"
+      },
+      "description": "Specify condition and response"
     }
   ],
   "icon": {

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.inbound.model;
 
 import io.camunda.connector.impl.feel.FEEL;
+import java.util.Map;
+import java.util.function.Function;
 
 public record WebhookConnectorProperties(
     String context,
@@ -16,7 +18,8 @@ public record WebhookConnectorProperties(
     String hmacHeader,
     String hmacAlgorithm,
     @FEEL HMACScope[] hmacScopes,
-    WebhookAuthorization auth) {
+    WebhookAuthorization auth,
+    Function<Object, Map> responseBodyExpression) {
 
   public WebhookConnectorProperties(WebhookConnectorPropertiesWrapper wrapper) {
     this(
@@ -30,7 +33,8 @@ public record WebhookConnectorProperties(
         wrapper.inbound.hmacScopes != null
             ? wrapper.inbound.hmacScopes
             : new HMACScope[] {HMACScope.BODY},
-        wrapper.inbound.auth);
+        wrapper.inbound.auth,
+        wrapper.inbound.responseBodyExpression);
   }
 
   public record WebhookConnectorPropertiesWrapper(WebhookConnectorProperties inbound) {}

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookProcessingResultImpl.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookProcessingResultImpl.java
@@ -21,7 +21,7 @@ public class WebhookProcessingResultImpl implements WebhookProcessingResult {
 
   @Override
   public Object body() {
-    return Optional.ofNullable(body).orElse(Collections.emptyMap());
+    return body;
   }
 
   @Override

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/JWTIntegrationTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/JWTIntegrationTest.java
@@ -9,7 +9,6 @@ package io.camunda.connector.inbound.authorization;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.auth0.jwk.Jwk;
 import com.auth0.jwk.JwkProvider;
@@ -113,7 +112,7 @@ public class JWTIntegrationTest {
     WebhookProcessingResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
 
     // then
-    assertEquals(objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.body());
+    // Happy case, nothing thrown
   }
 
   @Test
@@ -147,7 +146,7 @@ public class JWTIntegrationTest {
     WebhookProcessingResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
 
     // then
-    assertEquals(objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.body());
+    // Happy case, nothing thrown
   }
 
   @Test

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/TestWebhookProcessingPayload.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/TestWebhookProcessingPayload.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public record TestWebhookProcessingPayload(
     String requestURL,
     String method,
+    Map<String, Object> body,
     Map<String, String> headers,
     Map<String, String> params,
     byte[] rawBody)
@@ -21,6 +22,7 @@ public record TestWebhookProcessingPayload(
     this(
         null,
         null,
+        Map.of(),
         Map.of(
             HttpHeaders.AUTHORIZATION.toLowerCase(),
             "Bearer " + token,

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
@@ -110,6 +110,8 @@ public class HMACTwilioSignatureTest {
 
     private String requestURL;
     private String method;
+
+    private Map<String, Object> bodyAsMap;
     private Map<String, String> headers;
     private Map<String, String> params;
     private String body;
@@ -123,6 +125,11 @@ public class HMACTwilioSignatureTest {
     @Override
     public String method() {
       return method;
+    }
+
+    @Override
+    public Map<String, Object> body() {
+      return bodyAsMap;
     }
 
     @Override


### PR DESCRIPTION
## ⚠️ please ignore

## Description

feat(webhook): added response body expression

## Related issues

- https://github.com/camunda/connector-sdk/pull/531

## Testing done

`responseBodyExpression=<none>`

```
curl -X GET "http://localhost:8080/inbound/test00?hub.mode=subscribe&hub.challenge=12345" -vvv

Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test00?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:39:08 GMT
<
* Connection #0 to host localhost left intact
{"type":"START_EVENT","correlationPointId":"2251799813685628","activated":true,"responseData":{"processInstanceKey":2251799813685650,"bpmnProcessId":"Process_12rfq2j","processDefinitionKey":2251799813685628,"version":3},"errorData":null}
```

----

`responseBodyExpression=if get value(request.params, "hub.mode") = "subscribe" then {"hub.challenge": get value(request.params, "hub.challenge")} else null`


```
curl -X POST "http://localhost:8080/inbound/test01?hub.mode=fake&hub.challenge=12345" -vvv

*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test01?hub.mode=fake&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:35:31 GMT
<
* Connection #0 to host localhost left intact
{"type":"START_EVENT","correlationPointId":"2251799813685374","activated":true,"responseData":{"processInstanceKey":2251799813685426,"bpmnProcessId":"Process_12rfq2j","processDefinitionKey":2251799813685374,"version":1},"errorData":null}
```

```
curl -X GET "http://localhost:8080/inbound/test01?hub.mode=subscribe&hub.challenge=12345" -vvv

Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test01?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:36:19 GMT
<
* Connection #0 to host localhost left intact
{"hub.challenge":"12345"}
```

----

`responseBodyExpression= if get value(request.params, "hub.mode") = "subscribe" then {"hub.challenge": get value(request.params, "hub.challenge")} else {}`

```
curl -X POST "http://localhost:8080/inbound/test02?hub.mode=fake&hub.challenge=12345" -vvv

*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test02?hub.mode=fake&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:37:36 GMT
<
* Connection #0 to host localhost left intact
{}
```

```
curl -X GET "http://localhost:8080/inbound/test02?hub.mode=subscribe&hub.challenge=12345" -vvv

Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test02?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:37:59 GMT
<
* Connection #0 to host localhost left intact
{"hub.challenge":"12345"}
```

---

`responseBodyExpression=if get value(request.body, "key01") = "yes" then {"myResponse": get value(request.headers, "X-Response")} else null`

```
curl -X POST -H "Content-Type: application/json" -H "X-Response: teeeeest" -d '{"key01":"no"}' "http://localhost:8080/inbound/test03" -vvv

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test03 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Content-Type: application/json
> X-Response: teeeeest
> Content-Length: 14
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:45:14 GMT
<
* Connection #0 to host localhost left intact
{"type":"START_EVENT","correlationPointId":"2251799813685851","activated":true,"responseData":{"processInstanceKey":2251799813685993,"bpmnProcessId":"Process_12rfq2j","processDefinitionKey":2251799813685851,"version":4},"errorData":null}
```

```
curl -X POST -H "Content-Type: application/json" -H "X-Response: teeeeest" -d '{"key01":"yes"}' "http://localhost:8080/inbound/test03" -vvv

Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test03 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Content-Type: application/json
> X-Response: teeeeest
> Content-Length: 15
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Wed, 19 Jul 2023 17:51:45 GMT
<
* Connection #0 to host localhost left intact
{"myResponse":"teeeeest"}
```
