### PR TITLE
feat: introduce request body expression

### DIFF
--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestWebhookConnector.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/app/TestWebhookConnector.java
@@ -18,31 +18,24 @@ package io.camunda.connector.runtime.app;
 
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import java.util.Map;
 
 @InboundConnector(name = "TEST_WEBHOOK", type = "io.camunda:test-webhook:1")
 public class TestWebhookConnector implements WebhookConnectorExecutable {
 
   @Override
-  public WebhookProcessingResult triggerWebhook(WebhookProcessingPayload webhookProcessingPayload)
+  public WebhookResult triggerWebhook(WebhookProcessingPayload webhookProcessingPayload)
       throws Exception {
-    return new WebhookProcessingResult() {
-      @Override
-      public Object body() {
-        return Map.of("bodyKey", "bodyVal");
-      }
+    return new WebhookResult() {
 
       @Override
-      public Map<String, String> headers() {
-        return Map.of("X-Header", "XValue");
-      }
-
-      @Override
-      public Map<String, String> params() {
-        return Map.of("param1", "value1");
+      public MappedHttpRequest request() {
+        return new MappedHttpRequest(
+            Map.of("bodyKey", "bodyVal"), Map.of("X-Header", "XValue"), Map.of("param1", "value1"));
       }
 
       @Override

--- a/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/spring-boot-starter-camunda-connectors/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.impl.inbound.StartEventCorrelationPoint;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorContextImpl;
 import io.camunda.connector.runtime.core.inbound.InboundConnectorDefinitionImpl;
@@ -106,7 +106,7 @@ public class WebhookControllerPlainJavaTests {
     WebhookConnectorExecutable executable = mock(WebhookConnectorExecutable.class);
     try {
       Mockito.when(executable.triggerWebhook(any(WebhookProcessingPayload.class)))
-          .thenReturn(mock(WebhookProcessingResult.class));
+          .thenReturn(mock(WebhookResult.class));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/SnsWebhookExecutable.java
@@ -13,9 +13,10 @@ import com.amazonaws.services.sns.message.SnsSubscriptionConfirmation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.annotation.InboundConnector;
 import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
 import io.camunda.connector.api.inbound.webhook.WebhookConnectorExecutable;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.aws.ObjectMapperSupplier;
 import io.camunda.connector.sns.inbound.model.SnsWebhookConnectorProperties;
 import io.camunda.connector.sns.inbound.model.SnsWebhookProcessingResult;
@@ -51,7 +52,7 @@ public class SnsWebhookExecutable implements WebhookConnectorExecutable {
   }
 
   @Override
-  public WebhookProcessingResult triggerWebhook(WebhookProcessingPayload webhookProcessingPayload)
+  public WebhookResult triggerWebhook(WebhookProcessingPayload webhookProcessingPayload)
       throws Exception {
     checkMessageAllowListed(webhookProcessingPayload);
     Map bodyAsMap = objectMapper.readValue(webhookProcessingPayload.rawBody(), Map.class);
@@ -76,18 +77,16 @@ public class SnsWebhookExecutable implements WebhookConnectorExecutable {
     confirmation.confirmSubscription();
 
     return new SnsWebhookProcessingResult(
-        bodyAsMap,
-        webhookProcessingPayload.headers(),
-        webhookProcessingPayload.params(),
+        new MappedHttpRequest(
+            bodyAsMap, webhookProcessingPayload.headers(), webhookProcessingPayload.params()),
         Map.of("snsEventType", "Subscription"));
   }
 
   private SnsWebhookProcessingResult handleNotification(
       WebhookProcessingPayload webhookProcessingPayload, Map bodyAsMap) {
     return new SnsWebhookProcessingResult(
-        bodyAsMap,
-        webhookProcessingPayload.headers(),
-        webhookProcessingPayload.params(),
+        new MappedHttpRequest(
+            bodyAsMap, webhookProcessingPayload.headers(), webhookProcessingPayload.params()),
         Map.of("snsEventType", "Notification"));
   }
 

--- a/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookProcessingResult.java
+++ b/connectors/aws/aws-sns/src/main/java/io/camunda/connector/sns/inbound/model/SnsWebhookProcessingResult.java
@@ -6,44 +6,27 @@
  */
 package io.camunda.connector.sns.inbound.model;
 
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-public class SnsWebhookProcessingResult implements WebhookProcessingResult {
+public class SnsWebhookProcessingResult implements WebhookResult {
 
-  private Map<String, Object> body;
-  private Map<String, String> headers;
-  private Map<String, String> params;
+  private MappedHttpRequest request;
   private Map<String, Object> connectorData;
 
   public SnsWebhookProcessingResult() {}
 
-  public SnsWebhookProcessingResult(
-      Map<String, Object> body,
-      Map<String, String> headers,
-      Map<String, String> params,
-      Map<String, Object> connectorData) {
-    this.body = body;
-    this.headers = headers;
-    this.params = params;
+  public SnsWebhookProcessingResult(MappedHttpRequest request, Map<String, Object> connectorData) {
+    this.request = request;
     this.connectorData = connectorData;
   }
 
   @Override
-  public Map<String, Object> body() {
-    return Optional.ofNullable(body).orElse(Collections.emptyMap());
-  }
-
-  @Override
-  public Map<String, String> headers() {
-    return Optional.ofNullable(headers).orElse(Collections.emptyMap());
-  }
-
-  @Override
-  public Map<String, String> params() {
-    return Optional.ofNullable(params).orElse(Collections.emptyMap());
+  public MappedHttpRequest request() {
+    return request;
   }
 
   @Override

--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -43,7 +43,6 @@ The response will contain the result of the called Slack method.
       "ts": "1654636029.472959"
   }
 }
-
 ```
 
 ## Element Template

--- a/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProcessingResult.java
+++ b/connectors/slack/src/main/java/io/camunda/connector/slack/inbound/model/SlackWebhookProcessingResult.java
@@ -6,36 +6,37 @@
  */
 package io.camunda.connector.slack.inbound.model;
 
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
-import java.util.Collections;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
+import io.camunda.connector.api.inbound.webhook.WebhookHttpResponse;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import java.util.Map;
-import java.util.Optional;
 
-public class SlackWebhookProcessingResult implements WebhookProcessingResult {
+public class SlackWebhookProcessingResult implements WebhookResult {
 
-  private final Map<String, Object> body;
-  private final Map<String, String> headers;
+  private MappedHttpRequest request;
   private final Map<String, Object> connectorData;
 
+  private WebhookHttpResponse response;
+
   public SlackWebhookProcessingResult(
-      Map<String, Object> body, Map<String, String> headers, Map<String, Object> connectorData) {
-    this.body = body;
-    this.headers = headers;
+      MappedHttpRequest request, Map<String, Object> connectorData, WebhookHttpResponse response) {
+    this.request = request;
     this.connectorData = connectorData;
+    this.response = response;
   }
 
   @Override
-  public Object body() {
-    return Optional.ofNullable(body).orElse(Collections.emptyMap());
-  }
-
-  @Override
-  public Map<String, String> headers() {
-    return Optional.ofNullable(headers).orElse(Collections.emptyMap());
+  public MappedHttpRequest request() {
+    return request;
   }
 
   @Override
   public Map<String, Object> connectorData() {
     return connectorData;
+  }
+
+  @Override
+  public WebhookHttpResponse response() {
+    return response;
   }
 }

--- a/connectors/slack/src/test/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutableTest.java
+++ b/connectors/slack/src/test/java/io/camunda/connector/slack/inbound/SlackInboundWebhookExecutableTest.java
@@ -95,8 +95,8 @@ class SlackInboundWebhookExecutableTest {
     final var result = testObject.triggerWebhook(payload);
 
     assertNotNull(result);
-    assertThat(result.body()).isInstanceOf(Map.class);
-    assertThat((Map) result.body()).containsEntry(FIELD_TYPE, "myType");
+    assertThat(result.request().body()).isInstanceOf(Map.class);
+    assertThat((Map) result.request().body()).containsEntry(FIELD_TYPE, "myType");
   }
 
   @Test
@@ -145,8 +145,9 @@ class SlackInboundWebhookExecutableTest {
     final var result = testObject.triggerWebhook(payload);
 
     assertNotNull(result);
-    assertThat(result.body()).isInstanceOf(Map.class);
-    assertThat((Map) result.body()).containsEntry(FIELD_CHALLENGE, "aAaAaAaAaAaAaAaAaAaA");
+    assertThat(result.request().body()).isInstanceOf(Map.class);
+    assertThat((Map) result.request().body())
+        .containsEntry(FIELD_CHALLENGE, "aAaAaAaAaAaAaAaAaAaA");
   }
 
   @Test
@@ -173,10 +174,10 @@ class SlackInboundWebhookExecutableTest {
     final var result = testObject.triggerWebhook(payload);
 
     assertNotNull(result);
-    assertThat(result.body()).isInstanceOf(Map.class);
-    assertThat((Map) result.body())
+    assertThat(result.request().body()).isInstanceOf(Map.class);
+    assertThat((Map) result.response().body())
         .containsEntry(COMMAND_RESPONSE_TYPE_KEY, COMMAND_RESPONSE_TYPE_DEFAULT_VALUE);
-    assertThat((Map) result.body())
+    assertThat((Map) result.response().body())
         .containsEntry(COMMAND_RESPONSE_TEXT_KEY, COMMAND_RESPONSE_TEXT_DEFAULT_VALUE);
     assertThat((Map) result.connectorData()).containsEntry(FORM_VALUE_COMMAND, "/test123");
     assertThat((Map) result.connectorData()).containsEntry("text", "hello world");
@@ -206,10 +207,10 @@ class SlackInboundWebhookExecutableTest {
     final var result = testObject.triggerWebhook(payload);
 
     assertNotNull(result);
-    assertThat(result.body()).isInstanceOf(Map.class);
-    assertThat((Map) result.body())
+    assertThat(result.request().body()).isInstanceOf(Map.class);
+    assertThat((Map) result.response().body())
         .containsEntry(COMMAND_RESPONSE_TYPE_KEY, COMMAND_RESPONSE_TYPE_DEFAULT_VALUE);
-    assertThat((Map) result.body())
+    assertThat((Map) result.response().body())
         .containsEntry(COMMAND_RESPONSE_TEXT_KEY, COMMAND_RESPONSE_TEXT_DEFAULT_VALUE);
     assertThat((Map) result.connectorData()).containsEntry(FORM_VALUE_COMMAND, "/test123");
     assertThat((Map) result.connectorData()).containsEntry("text", "hello world");

--- a/connectors/webhook/element-templates/webhook-connector-intermediate.json
+++ b/connectors/webhook/element-templates/webhook-connector-intermediate.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook connector",
   "id": "io.camunda.connectors.webhook.WebhookConnectorIntermediate.v1",
-  "version": 3,
+  "version": 4,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {
@@ -37,6 +37,10 @@
     {
       "id": "variable-mapping",
       "label": "Variable mapping"
+    },
+    {
+      "id": "webhookResponse",
+      "label": "Webhook response"
     }
   ],
   "properties": [
@@ -423,6 +427,18 @@
         "name": "resultExpression"
       },
       "description": "Expression to map the inbound payload to process variables"
+    },
+    {
+      "label": "Response body expression",
+      "type": "Text",
+      "group": "webhookResponse",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.responseBodyExpression"
+      },
+      "description": "Specify condition and response"
     }
   ],
   "icon": {

--- a/connectors/webhook/element-templates/webhook-connector-start-event.json
+++ b/connectors/webhook/element-templates/webhook-connector-start-event.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
   "name": "Webhook connector",
   "id": "io.camunda.connectors.webhook.WebhookConnector.v1",
-  "version": 5,
+  "version": 6,
   "description": "Configure webhook to receive callbacks",
   "documentationRef": "https://docs.camunda.io/docs/components/connectors/out-of-the-box-connectors/http-webhook/",
   "category": {
@@ -35,6 +35,10 @@
     {
       "id": "variable-mapping",
       "label": "Variable mapping"
+    },
+    {
+      "id": "webhookResponse",
+      "label": "Webhook response"
     }
   ],
   "properties": [
@@ -383,6 +387,18 @@
         "name": "resultExpression"
       },
       "description": "Expression to map the inbound payload to process variables"
+    },
+    {
+      "label": "Response body expression",
+      "type": "Text",
+      "group": "webhookResponse",
+      "feel": "required",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:property",
+        "name": "inbound.responseBodyExpression"
+      },
+      "description": "Specify condition and response"
     }
   ],
   "icon": {

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/WebhookAuthChecker.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/WebhookAuthChecker.java
@@ -10,9 +10,9 @@ import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.JwkProviderBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HttpHeaders;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
-import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
-import io.camunda.connector.api.inbound.webhook.WebhookResultContext.Request;
+import io.camunda.connector.api.inbound.webhook.WebhookTriggerResultContext;
 import io.camunda.connector.inbound.model.WebhookAuthorization;
 import io.camunda.connector.inbound.model.WebhookAuthorization.ApiKeyAuth;
 import io.camunda.connector.inbound.model.WebhookAuthorization.BasicAuth;
@@ -113,14 +113,14 @@ public class WebhookAuthChecker {
   private void checkApiKeyAuth(ApiKeyAuth expectedAuthorization, WebhookProcessingPayload payload)
       throws IOException {
 
-    WebhookResultContext result =
-        new WebhookResultContext(
-            new Request(
+    WebhookTriggerResultContext result =
+        new WebhookTriggerResultContext(
+            new MappedHttpRequest(
                 HttpWebhookUtil.transformRawBodyToMap(
                     payload.rawBody(), HttpWebhookUtil.extractContentType(payload.headers())),
                 payload.headers(),
-                payload.params(),
-                Map.of()));
+                payload.params()),
+            Map.of());
 
     String authValue = expectedAuthorization.apiKeyLocator().apply(result);
     if (!expectedAuthorization.apiKey().equals(authValue)) {

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -7,6 +7,8 @@
 package io.camunda.connector.inbound.model;
 
 import io.camunda.connector.api.annotation.FEEL;
+import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
+import java.util.function.Function;
 
 public record WebhookConnectorProperties(
     String context,
@@ -16,7 +18,8 @@ public record WebhookConnectorProperties(
     String hmacHeader,
     String hmacAlgorithm,
     @FEEL HMACScope[] hmacScopes,
-    WebhookAuthorization auth) {
+    WebhookAuthorization auth,
+    Function<WebhookResultContext, Object> responseBodyExpression) {
 
   public WebhookConnectorProperties(WebhookConnectorPropertiesWrapper wrapper) {
     this(
@@ -28,7 +31,8 @@ public record WebhookConnectorProperties(
         wrapper.inbound.hmacAlgorithm,
         // default to BODY if no scopes are provided
         getOrDefault(wrapper.inbound.hmacScopes, new HMACScope[] {HMACScope.BODY}),
-        getOrDefault(wrapper.inbound.auth, new WebhookAuthorization.None()));
+        getOrDefault(wrapper.inbound.auth, new WebhookAuthorization.None()),
+        wrapper.inbound.responseBodyExpression);
   }
 
   public record WebhookConnectorPropertiesWrapper(WebhookConnectorProperties inbound) {}

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookProcessingResultImpl.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookProcessingResultImpl.java
@@ -6,32 +6,25 @@
  */
 package io.camunda.connector.inbound.model;
 
-import com.google.common.base.Objects;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.MappedHttpRequest;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResultContext;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
-public class WebhookProcessingResultImpl implements WebhookProcessingResult {
+public class WebhookProcessingResultImpl implements WebhookResult {
 
-  private Object body;
-  private Map<String, String> headers;
-  private Map<String, String> params;
+  private MappedHttpRequest request;
   private Map<String, Object> connectorData;
 
-  @Override
-  public Object body() {
-    return Optional.ofNullable(body).orElse(Collections.emptyMap());
-  }
+  private Function<WebhookResultContext, Object> responseBodyExpression;
 
   @Override
-  public Map<String, String> headers() {
-    return Optional.ofNullable(headers).orElse(Collections.emptyMap());
-  }
-
-  @Override
-  public Map<String, String> params() {
-    return Optional.ofNullable(params).orElse(Collections.emptyMap());
+  public MappedHttpRequest request() {
+    return request;
   }
 
   @Override
@@ -39,20 +32,25 @@ public class WebhookProcessingResultImpl implements WebhookProcessingResult {
     return Optional.ofNullable(connectorData).orElse(Collections.emptyMap());
   }
 
-  public void setBody(Object body) {
-    this.body = body;
+  @Override
+  public Function<WebhookResultContext, Object> responseBodyExpression() {
+    if (responseBodyExpression != null) {
+      return responseBodyExpression;
+    }
+    return (response) -> null;
   }
 
-  public void setHeaders(Map<String, String> headers) {
-    this.headers = headers;
-  }
-
-  public void setParams(Map<String, String> params) {
-    this.params = params;
+  public void setRequest(MappedHttpRequest request) {
+    this.request = request;
   }
 
   public void setConnectorData(Map<String, Object> connectorData) {
     this.connectorData = connectorData;
+  }
+
+  public void setResponseBodyExpression(
+      Function<WebhookResultContext, Object> responseBodyExpression) {
+    this.responseBodyExpression = responseBodyExpression;
   }
 
   @Override
@@ -60,28 +58,25 @@ public class WebhookProcessingResultImpl implements WebhookProcessingResult {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     WebhookProcessingResultImpl that = (WebhookProcessingResultImpl) o;
-    return Objects.equal(body, that.body)
-        && Objects.equal(headers, that.headers)
-        && Objects.equal(params, that.params)
-        && Objects.equal(connectorData, that.connectorData);
+    return Objects.equals(request, that.request)
+        && Objects.equals(connectorData, that.connectorData)
+        && Objects.equals(responseBodyExpression, that.responseBodyExpression);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(body, headers, params, connectorData);
+    return Objects.hash(request, connectorData, responseBodyExpression);
   }
 
   @Override
   public String toString() {
-    return "WebhookResponsePayloadImpl{"
-        + "body="
-        + body
-        + ", headers="
-        + headers
-        + ", params="
-        + params
+    return "WebhookProcessingResultImpl{"
+        + "request="
+        + request
         + ", connectorData="
         + connectorData
+        + ", responseBodyExpression="
+        + responseBodyExpression
         + '}';
   }
 }

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/HttpWebhookExecutableTest.java
@@ -55,7 +55,7 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    Assertions.assertThat((Map) result.body()).containsEntry("key", "value");
+    Assertions.assertThat((Map) result.request().body()).containsEntry("key", "value");
   }
 
   @Test
@@ -80,8 +80,8 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    Assertions.assertThat((Map) result.body()).containsEntry("key1", "value1");
-    Assertions.assertThat((Map) result.body()).containsEntry("key2", "value2");
+    Assertions.assertThat((Map) result.request().body()).containsEntry("key1", "value1");
+    Assertions.assertThat((Map) result.request().body()).containsEntry("key2", "value2");
   }
 
   @Test
@@ -106,7 +106,7 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    Assertions.assertThat((Map) result.body()).containsEntry("key", "value");
+    Assertions.assertThat((Map) result.request().body()).containsEntry("key", "value");
   }
 
   @Test
@@ -188,7 +188,7 @@ class HttpWebhookExecutableTest {
     testObject.activate(ctx);
     var result = testObject.triggerWebhook(payload);
 
-    Assertions.assertThat((Map) result.body()).containsEntry("key", "value");
+    Assertions.assertThat((Map) result.request().body()).containsEntry("key", "value");
   }
 
   @Test

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/JWTIntegrationTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/authorization/JWTIntegrationTest.java
@@ -20,7 +20,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.impl.inbound.result.MessageCorrelationResult;
 import io.camunda.connector.inbound.HttpWebhookExecutable;
 import io.camunda.connector.inbound.utils.ObjectMapperSupplier;
@@ -110,10 +110,11 @@ public class JWTIntegrationTest {
     // webhook connector trigger
     TestWebhookProcessingPayload payload =
         new TestWebhookProcessingPayload(generateJWTToken(roles, false), REQ_BODY);
-    WebhookProcessingResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
+    WebhookResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
 
     // then
-    assertEquals(objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.body());
+    assertEquals(
+        objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.request().body());
   }
 
   @Test
@@ -144,10 +145,11 @@ public class JWTIntegrationTest {
     // webhook connector trigger
     TestWebhookProcessingPayload payload =
         new TestWebhookProcessingPayload(generateJWTToken(roles, true), REQ_BODY);
-    WebhookProcessingResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
+    WebhookResult webhookProcessingResult = httpWebhookExecutable.triggerWebhook(payload);
 
     // then
-    assertEquals(objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.body());
+    assertEquals(
+        objectMapper.readValue(REQ_BODY, Map.class), webhookProcessingResult.request().body());
   }
 
   @Test

--- a/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
+++ b/connectors/webhook/src/test/java/io/camunda/connector/inbound/signature/HMACTwilioSignatureTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.connector.api.inbound.webhook.WebhookProcessingPayload;
-import io.camunda.connector.api.inbound.webhook.WebhookProcessingResult;
+import io.camunda.connector.api.inbound.webhook.WebhookResult;
 import io.camunda.connector.inbound.HttpWebhookExecutable;
 import io.camunda.connector.inbound.utils.HttpMethods;
 import io.camunda.connector.inbound.utils.ObjectMapperSupplier;
@@ -70,7 +70,7 @@ public class HMACTwilioSignatureTest {
     var context = InboundConnectorContextBuilder.create().properties(baseProperties).build();
     httpWebhookExecutable.activate(context);
     // When
-    WebhookProcessingResult webhookProcessingResult =
+    WebhookResult webhookProcessingResult =
         httpWebhookExecutable.triggerWebhook(webhookProcessingPayload);
     // Then assert that result not null, and validation pass done, without exceptions
     assertThat(webhookProcessingResult).isNotNull();
@@ -87,7 +87,7 @@ public class HMACTwilioSignatureTest {
 
     httpWebhookExecutable.activate(context);
     // When
-    WebhookProcessingResult webhookProcessingResult =
+    WebhookResult webhookProcessingResult =
         httpWebhookExecutable.triggerWebhook(webhookProcessingPayload);
     // Then assert that result not null, and validation pass done, without exceptions
     assertThat(webhookProcessingResult).isNotNull();


### PR DESCRIPTION
feat: introduce request body expression

Changes from previous PR:
- exposed post-processing function
- now, if response body expression not defined, returning nothing
- to return correlation data, user has to use `correlation` variable: `=if ... then correlation else ...` or `=if ... then {correlationResult: correlation} else ...`

## Notes

- Failing due to expected changes https://github.com/camunda/connector-sdk/pull/531 are not there yet.
- https://github.com/camunda/connectors-bundle/pull/902 is still compatible

## Testing done

`responseBodyExpression=<none>`

```
curl -X GET "http://localhost:8080/inbound/test00?hub.mode=subscribe&hub.challenge=12345" -vvv
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test00?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Length: 0
< Date: Mon, 24 Jul 2023 13:36:43 GMT
<
* Connection #0 to host localhost left intact
```

---

`responseBodyExpression=if get value(request.params, "hub.mode") = "subscribe" then {"hub.challenge": get value(request.params, "hub.challenge")} else null`

```
curl -X POST "http://localhost:8080/inbound/test00?hub.mode=fake&hub.challenge=12345" -vvv
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test00?hub.mode=fake&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Length: 0
< Date: Mon, 24 Jul 2023 13:38:15 GMT
<
* Connection #0 to host localhost left intact
```

```
curl -X GET "http://localhost:8080/inbound/test00?hub.mode=subscribe&hub.challenge=12345" -vvv
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test00?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Mon, 24 Jul 2023 13:39:34 GMT
<
* Connection #0 to host localhost left intact
{"hub.challenge":"12345"}
```

---

`responseBodyExpression=if get value(request.params, "hub.mode") = "subscribe" then {"hub.challenge": get value(request.params, "hub.challenge")} else {}`

```
curl -X POST "http://localhost:8080/inbound/test00?hub.mode=fake&hub.challenge=12345" -vvv
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test00?hub.mode=fake&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Mon, 24 Jul 2023 13:40:52 GMT
<
* Connection #0 to host localhost left intact
{}
```

```
curl -X GET "http://localhost:8080/inbound/test00?hub.mode=subscribe&hub.challenge=12345" -vvv
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /inbound/test00?hub.mode=subscribe&hub.challenge=12345 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Mon, 24 Jul 2023 13:41:26 GMT
<
* Connection #0 to host localhost left intact
{"hub.challenge":"12345"}
```

---

`responseBodyExpression=if get value(request.body, "key01") = "yes" then {"myResponse": get value(request.headers, "x-response")} else null`

```
curl -X POST -H "Content-Type: application/json" -H "X-Response: teeeeest" -d '{"key01":"no"}' "http://localhost:8080/inbound/test00" -vvv
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test00 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Content-Type: application/json
> X-Response: teeeeest
> Content-Length: 14
>
< HTTP/1.1 200
< Content-Length: 0
< Date: Mon, 24 Jul 2023 13:43:23 GMT
<
* Connection #0 to host localhost left intact
```

```
curl -X POST -H "Content-Type: application/json" -H "X-Response: teeeeest" -d '{"key01":"yes"}' "http://localhost:8080/inbound/test00" -vvv
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test00 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Content-Type: application/json
> X-Response: teeeeest
> Content-Length: 15
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Mon, 24 Jul 2023 13:45:42 GMT
<
* Connection #0 to host localhost left intact
{"myResponse":"teeeeest"}
```

---

`responseBodyExpression=if get value(request.body, "key01") = "yes" then correlation else null`

```
curl -X POST -H "Content-Type: application/json" -H "X-Response: teeeeest" -d '{"key01":"yes"}' "http://localhost:8080/inbound/test00" -vvv
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /inbound/test00 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> Content-Type: application/json
> X-Response: teeeeest
> Content-Length: 15
>
< HTTP/1.1 200
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Mon, 24 Jul 2023 13:47:04 GMT
<
* Connection #0 to host localhost left intact
{"activated":true,"errorData":{"empty":true,"present":false},"type":"START_EVENT","correlationPointId":"2251799813688311","responseData":{"empty":false,"present":true}}
```