### PR TITLE
fix: add default value for auth to prevent errors with old deployments

### DIFF
--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/WebhookAuthChecker.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/authorization/WebhookAuthChecker.java
@@ -65,7 +65,7 @@ public class WebhookAuthChecker {
    */
   public void checkAuthorization(WebhookProcessingPayload payload) throws IOException {
 
-    if (authorization instanceof WebhookAuthorization.None) {
+    if (authorization == null || authorization instanceof WebhookAuthorization.None) {
       // no auth expected, proceed
       return;
     }

--- a/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
+++ b/connectors/webhook/src/main/java/io/camunda/connector/inbound/model/WebhookConnectorProperties.java
@@ -27,11 +27,13 @@ public record WebhookConnectorProperties(
         wrapper.inbound.hmacHeader,
         wrapper.inbound.hmacAlgorithm,
         // default to BODY if no scopes are provided
-        wrapper.inbound.hmacScopes != null
-            ? wrapper.inbound.hmacScopes
-            : new HMACScope[] {HMACScope.BODY},
-        wrapper.inbound.auth);
+        getOrDefault(wrapper.inbound.hmacScopes, new HMACScope[] {HMACScope.BODY}),
+        getOrDefault(wrapper.inbound.auth, new WebhookAuthorization.None()));
   }
 
   public record WebhookConnectorPropertiesWrapper(WebhookConnectorProperties inbound) {}
+
+  private static <T> T getOrDefault(T value, T defaultValue) {
+    return value != null ? value : defaultValue;
+  }
 }


### PR DESCRIPTION
## Description

GitHub connector or old webhook connectors can fail if there is no auth.

